### PR TITLE
Do not delete previous startpage after first use

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+core/app/

--- a/core/columns.php
+++ b/core/columns.php
@@ -72,6 +72,7 @@
                             mysqli_free_result($result);
                         }
 
+                        $checked_tables_counter=0;
                         if ( isset( $_POST['table'] ) )
                         {
                             foreach ( $_POST['table'] as $table )
@@ -132,14 +133,31 @@
                      </div>';
                                         $i++;
                                     }
+                                    $checked_tables_counter++;
                                 }
                             }
                         }
                         ?>
 
                         <div class="row">
+                            <div class="col-12 offset-2">
+                                <p class="form-check">
+                                    <small id="passwordHelpBlock" class="form-text text-muted">
+                                        Cruddiy will create a fresh startpage in the app/ sub-folder, with link<?php echo $checked_tables_counter > 1 ? 's' : '' ?> to manage the table<?php echo $checked_tables_counter > 1 ? 's' : '' ?> above.<br>
+                                        If you have used Cruddiy on other tables before, your start page will be replaced by the fresh one, and previous links will be lost.
+                                    </small>
+                                    <input class="form-check-input" type="checkbox" value="true" id="keep_startpage" name="keep_startpage">
+                                    <label class="form-check-label" for="keep_startpage">
+                                        Keep previously generated startpage page if it exists
+                                    </label>
+                                    <br>
+                                    <input class="form-check-input" type="checkbox" value="true" id="append_links" name="append_links">
+                                    <label class="form-check-label" for="append_links">
+                                        Append new link<?php echo $checked_tables_counter > 1 ? 's' : '' ?> to previously generated startpage page if necessary
+                                    </label>
+                                </p>
+                            </div>
                             <div class="col-12 offset-5">
-                                <label class="col-form-label mt-3" for="singlebutton"></label>
                                 <button type="submit" id="singlebutton" name="singlebutton" class="btn btn-primary">Generate pages</button>
                             </div>
                         </div>

--- a/core/columns.php
+++ b/core/columns.php
@@ -148,12 +148,12 @@
                                     </small>
                                     <input class="form-check-input" type="checkbox" value="true" id="keep_startpage" name="keep_startpage">
                                     <label class="form-check-label" for="keep_startpage">
-                                        Keep previously generated startpage page if it exists
+                                        Keep previously generated startpage if it exists
                                     </label>
                                     <br>
                                     <input class="form-check-input" type="checkbox" value="true" id="append_links" name="append_links">
                                     <label class="form-check-label" for="append_links">
-                                        Append new link<?php echo $checked_tables_counter > 1 ? 's' : '' ?> to previously generated startpage page if necessary
+                                        Append new link<?php echo $checked_tables_counter > 1 ? 's' : '' ?> to previously generated startpage if necessary
                                     </label>
                                 </p>
                             </div>

--- a/core/generate.php
+++ b/core/generate.php
@@ -11,6 +11,9 @@ $index_table_rows = '';
 $index_table_headers = '';
 $start_page = '';
 $sort = '';
+$excluded_keys = array('singlebutton', 'keep_startpage', 'append_links');
+$generate_start_checked_links = array();
+$startpage_filename = "app/index.php";
 
 function column_type($columnname){
     switch ($columnname) {
@@ -129,9 +132,10 @@ function generate_update($tablename, $create_records, $create_err_records, $crea
 }
 
 function count_index_colums($table) {
+    global $excluded_keys;
     $i = 0;
     foreach ( $_POST as $key => $value) {
-        if ($key == 'singlebutton') {
+        if (in_array($key, $excluded_keys)) {
             //echo "nope";
         }
         else if ($key == $table) {
@@ -180,7 +184,7 @@ foreach ($_POST as $key => $value) {
     $update_sql_id = '';
     $update_column_rows = '';
 
-    if ($key != 'singlebutton') {
+    if (!in_array($key, $excluded_keys)) {
         $i = 0;
         $j = 0;
         $max = count_index_colums($key)+1;

--- a/core/generate.php
+++ b/core/generate.php
@@ -1,9 +1,3 @@
-<pre>
-    <?php
-      //print_r($_POST);
-    ?>
-</pre>
-
 <?php
 
 require "app/config.php";
@@ -154,6 +148,10 @@ function count_index_colums($table) {
     }
     return $i;
 }
+
+// echo "<pre>";
+// print_r($_POST);
+// echo "</pre>";
 // Go trough the POST array
 // Every table is a key
 foreach ($_POST as $key => $value) {

--- a/core/generate.php
+++ b/core/generate.php
@@ -49,13 +49,59 @@ function generate_error(){
     echo "Generating Error file<br><br>";
 }
 
-function generate_start($start_page){
+function generate_start($start_page, $keep_startpage, $append_links){
     global $startfile;
-    $step0 = str_replace("{TABLE_BUTTONS}", $start_page, $startfile);
-    $destination_file = fopen("app/index.php", "w") or die("Unable to open file!");
-    fwrite($destination_file, $step0);
-    fclose($destination_file);
-    echo "Generating Startpage file<br>";
+    global $generate_start_checked_links;
+    global $startpage_filename;
+
+    if (!$keep_startpage) {
+        $step0 = str_replace("{TABLE_BUTTONS}", $start_page, $startfile);
+        $destination_file = fopen($startpage_filename, "w") or die("Unable to open fresh startpage file!");
+        fwrite($destination_file, $step0);
+        fclose($destination_file);
+        echo "Generating Startpage file<br>";
+    } else {
+        if ($append_links) {
+            // load existing template
+            echo "Retrieving existing Startpage file<br>";
+            $handle = fopen($startpage_filename, "r") or die("Unable to open existing startpage file!");;
+            $startfile = fread($handle, filesize($startpage_filename));
+            fclose($handle);
+            
+            // extract existing links from app/index.php
+            echo "Looking for new links to append to Startpage file<br>";
+            $link_matcher_pattern = '/href=["\']?([^"\'>]+)["\']?/im';
+            preg_match_all($link_matcher_pattern, $startfile, $startfile_links);
+            if (count($startfile_links)) {
+                foreach($startfile_links[1] as $startfile_link) {
+                    // echo '- Found existing link '.$startfile_link.'<br>';
+                }
+            }
+
+            // do not append links to app/index.php if they  already 
+            preg_match_all($link_matcher_pattern, $start_page, $start_page_links);
+            if (count($start_page_links)) {
+                foreach($start_page_links[1] as $start_page_link) {
+                    if (!in_array($start_page_link, $generate_start_checked_links)) {
+                        if (in_array($start_page_link, $startfile_links[1])) {
+                            echo '- Not appending '.$start_page_link.' as it already exists<br>';
+                        } else {
+                            echo '- Appending '.$start_page_link.'<br>';
+                            array_push($startfile_links[1], $start_page_link);
+                            $linkname = str_replace('-index.php', '', basename($start_page_link));
+                            $step0 = preg_replace('/<\/div>.*<\/center>/msx', "\t".'<a href="'.$start_page_link.'>" class="btn btn-primary" role="button">'.$linkname.'</a>'."\n</div>\n</center>", $startfile);
+                            $destination_file = fopen($startpage_filename, "w") or die("Unable to open file!");
+                            fwrite($destination_file, $step0);
+                            fclose($destination_file);
+                        }
+                        array_push($generate_start_checked_links, $start_page_link);
+                    }
+                }
+            }
+        }
+    }
+
+    
 }
 
 function generate_index($tablename,$tabledisplay,$index_table_headers,$index_table_rows,$column_id, $columns_available, $index_sql_search) {

--- a/core/generate.php
+++ b/core/generate.php
@@ -54,7 +54,8 @@ function generate_start($start_page, $keep_startpage, $append_links){
     global $generate_start_checked_links;
     global $startpage_filename;
 
-    if (!$keep_startpage) {
+    // make sure that a previous startpage was created before trying to keep it alive
+    if (!$keep_startpage || ($keep_startpage && !filesize($startpage_filename))) {
         $step0 = str_replace("{TABLE_BUTTONS}", $start_page, $startfile);
         $destination_file = fopen($startpage_filename, "w") or die("Unable to open fresh startpage file!");
         fwrite($destination_file, $step0);
@@ -89,7 +90,7 @@ function generate_start($start_page, $keep_startpage, $append_links){
                             echo '- Appending '.$start_page_link.'<br>';
                             array_push($startfile_links[1], $start_page_link);
                             $linkname = str_replace('-index.php', '', basename($start_page_link));
-                            $step0 = preg_replace('/<\/div>.*<\/center>/msx', "\t".'<a href="'.$start_page_link.'>" class="btn btn-primary" role="button">'.$linkname.'</a>'."\n</div>\n</center>", $startfile);
+                            $step0 = preg_replace('/<\/div>.*<\/center>/msx', "\t".'<a href="'.$start_page_link.'" class="btn btn-primary" role="button">'.$linkname.'</a>'."\n</div>\n</center>", $startfile);
                             $destination_file = fopen($startpage_filename, "w") or die("Unable to open file!");
                             fwrite($destination_file, $step0);
                             fclose($destination_file);

--- a/core/generate.php
+++ b/core/generate.php
@@ -426,7 +426,7 @@ foreach ($_POST as $key => $value) {
                     $start_page .= "\n\t";
                 }
 
-                generate_start($start_page);
+                generate_start($start_page, isset($_POST['keep_startpage']) && $_POST['keep_startpage'] == 'true' ? true : false, isset($_POST['append_links']) && $_POST['append_links'] == 'true' ? true : false);
                 generate_error();
                 generate_index($tablename,$tabledisplay,$index_table_headers,$index_table_rows,$column_id, $columns_available,$index_sql_search);
                 generate_create($tablename,$create_records, $create_err_records, $create_sqlcolumns, $create_numberofparams, $create_sql_params, $create_html, $create_postvars);


### PR DESCRIPTION
Hi @jan-vandenberg I appreciate Cruddiy so I thought I would implement a new time-saving feature as a thank you. Hope you enjoy it!

This PR adds two checkboxes on the Columns.php form:
- Keep previously generated startpage page if it exists
- Append new links to previously generated startpage page if necessary

![](https://files.italic.fr/chrome_1sZYw5Jl96.png)

These settings are useful when editting a CRUD that was previously generated with Cruddiy.
If you want to edit/regenerate the CRUD for **only a few tables**, your app/index.php gets recreated from scratch and the CRUD links that were previously generated for other tables are lost.

Now you can keep your previous app/index.php untouched, or even add the missing CRUD links if you are creating a CRUD for some freshly added extra tables!

What's included?

**Generic:**
- gitignored the app/ folder to ease repetitive testings

**Columns.php:**
- Bootstrap 4.5-compliant checkboxes
- Checked table counter variable to pluralize the new checkboxes labels if necessary

**generate.php:**
- extended `generate_index` function with new parameters
- new $_POST parameters variable declaration and sanitation enforcement
- $_POST debug bloc has moved next to $_POST parsing
- retrocompatibility with initial `generate_start` feature to avoid breaking stuff
- new log messages such as _"Retrieving existing Startpage file"_, _"Appending link"_, etc.
- global multiline case-insensitive regex to detect links
- optional preexisting links on the previous startpage log (commented out)
- link unicity / do not duplicate a link to a CRUD page if it's already somewhere on app/index.php
- regex-based replacement based on the default markup: appens links at the end of the existing groups, also works if groups are empty, doesn't require markup change (markup is invalid, needs refactoring)
- avoid duplicating log messages and appendings when a single link is repeated due to initial `$start_page` variable being concatenated and parsed multiple times (could be avoided, needs refactoring)