### PR TITLE
checkbox improvements on columns.php and tables.php

### DIFF
--- a/core/columns.php
+++ b/core/columns.php
@@ -127,8 +127,8 @@
                                         <input id="textinput_'.$tablename. '"name="'. $tablename. 'columns['.$i.'][columndisplay]" type="text" placeholder="Display field name in frontend" class="form-control">
                                     </div>
                                     <div class="col-md-4">
-                                        <input type="checkbox"  name="'.$tablename.'columns['.$i.'][columnvisible]" id="checkboxes-0" value="1">
-                                Visible in overview?</div>
+                                        <input type="checkbox"  name="'.$tablename.'columns['.$i.'][columnvisible]" id="checkboxes-'.$i.'" value="1">
+                                <label for="checkboxes-'.$i.'">Visible in overview?</label></div>
                      </div>';
                                         $i++;
                                     }

--- a/core/columns.php
+++ b/core/columns.php
@@ -72,6 +72,7 @@
                             mysqli_free_result($result);
                         }
 
+                        $checked_tables_counter=0;
                         if ( isset( $_POST['table'] ) )
                         {
                             foreach ( $_POST['table'] as $table )
@@ -127,11 +128,12 @@
                                         <input id="textinput_'.$tablename. '"name="'. $tablename. 'columns['.$i.'][columndisplay]" type="text" placeholder="Display field name in frontend" class="form-control">
                                     </div>
                                     <div class="col-md-4">
-                                        <input type="checkbox"  name="'.$tablename.'columns['.$i.'][columnvisible]" id="checkboxes-'.$i.'" value="1">
-                                <label for="checkboxes-'.$i.'">Visible in overview?</label></div>
+                                        <input type="checkbox"  name="'.$tablename.'columns['.$i.'][columnvisible]" id="checkboxes-'.$checked_tables_counter.'-'.$i.'" value="1">
+                                <label for="checkboxes-'.$checked_tables_counter.'-'.$i.'">Visible in overview?</label></div>
                      </div>';
                                         $i++;
                                     }
+                                    $checked_tables_counter++;
                                 }
                             }
                         }

--- a/core/columns.php
+++ b/core/columns.php
@@ -14,6 +14,13 @@
                 <div class="text-center">
                     <h4 class="mb-0">All available columns</h4>
                 </div>
+
+                <div class="col-md-4 offset-md-8">
+                    <input type="checkbox" id="checkall">
+                    <label for="checkall">Check/uncheck all</label>
+                </div>
+
+
                 <form class="form-horizontal" action="generate.php" method="post">
                     <fieldset>
                         <?php
@@ -154,5 +161,13 @@
 <script src="https://code.jquery.com/jquery-3.5.1.min.js" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
 <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
 <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/js/bootstrap.min.js" integrity="sha384-OgVRvuATP1z7JjHLkuOU7Xw704+h835Lr+6QL9UvYjZE3Ipu6Tp75j7Bh/kR0JKI" crossorigin="anonymous"></script>
+<script>
+$(document).ready(function () {
+    $('#checkall').click(function(e) {
+        var chb = $('.form-horizontal').find('input[type="checkbox"]');
+        chb.prop('checked', !chb.prop('checked'));
+    });
+});
+</script>
 </body>
 </html>

--- a/core/columns.php
+++ b/core/columns.php
@@ -125,7 +125,7 @@
                                         <input type="hidden" name="'.$tablename.'columns['.$i.'][tabledisplay]" value="'.$tabledisplay.'"/>
                                         <input type="hidden" name="'.$tablename.'columns['.$i.'][columnname]" value="'.$column[0].'"/>
                                         <input type="hidden" name="'.$tablename.'columns['.$i.'][columntype]" value="'.$column_type.'"/>
-                                        <input id="textinput_'.$tablename. '"name="'. $tablename. 'columns['.$i.'][columndisplay]" type="text" placeholder="Display field name in frontend" class="form-control">
+                                        <input id="textinput_'.$tablename. '-'.$i.'"name="'. $tablename. 'columns['.$i.'][columndisplay]" type="text" placeholder="Display field name in frontend" class="form-control">
                                     </div>
                                     <div class="col-md-4">
                                         <input type="checkbox"  name="'.$tablename.'columns['.$i.'][columnvisible]" id="checkboxes-'.$checked_tables_counter.'-'.$i.'" value="1">

--- a/core/tables.php
+++ b/core/tables.php
@@ -43,7 +43,7 @@
                                  <input id="textinput_'.$table. '" name="table['.$i.'][tabledisplay]" type="text" placeholder="Display table name in frontend" class="form-control">
                         </div>
                         <div class="col-md-3">
-                          <input class="mr-1" type="checkbox"  name="table['.$i.'][tablecheckbox]" id="checkboxes-0" value="1">Generate CRUD
+                          <input class="mr-1" type="checkbox"  name="table['.$i.'][tablecheckbox]" id="checkboxes-'.$i.'" value="1"><label for="checkboxes-'.$i.'">Generate CRUD</label>
                         </div>
                     </div>
   


### PR DESCRIPTION
This PR adds correct HTML `label for` attributes, making the labels clickable along with checkboxes for easier selection!

![Aucw7AAOY1](https://user-images.githubusercontent.com/17506424/113507239-83b8a700-9549-11eb-8b13-9b24e4bad56c.gif)

![vQzU5kyMBr](https://user-images.githubusercontent.com/17506424/113507213-700d4080-9549-11eb-9f69-b1b5b33ad06d.gif)


Also a check/uncheck all options on columns page :

![lbPVqTw00t](https://user-images.githubusercontent.com/17506424/113508680-a222a080-9551-11eb-99c5-7175949b760d.gif)

Definitely a time-saver on huge tables!