### PR TITLE
FIXED missing charset definition

### DIFF
--- a/core/relations.php
+++ b/core/relations.php
@@ -34,6 +34,19 @@ if(isset($_POST['index'])) {
 	$txt .= "\$db_password = '$password'; \n";
 	$txt .= "\$no_of_records_per_page = $numrecordsperpage; \n\n";
 	$txt .= "\$link = mysqli_connect(\$db_server, \$db_user, \$db_password, \$db_name); \n";
+
+    $txt .= '$query = "SHOW VARIABLES LIKE \'character_set_database\'";' ."\n";
+    $txt .= 'if ($result = mysqli_query($link, $query)) {' ."\n";
+    $txt .= '    while ($row = mysqli_fetch_row($result)) {' ."\n";
+    $txt .= '        if (!$link->set_charset($row[1])) {' ."\n";
+    $txt .= '            printf("Error loading character set $row[1]: %s\n", $link->error);' ."\n";
+    $txt .= '            exit();' ."\n";
+    $txt .= '        } else {' ."\n";
+    $txt .= '            // printf("Current character set: %s", $link->character_set_name());' ."\n";
+    $txt .= '        }' ."\n";
+    $txt .= '    }' ."\n";
+    $txt .= '}' ."\n";
+
 	$txt .= "\n?>";
 	fwrite($configfile, $txt);
 	fclose($configfile);


### PR DESCRIPTION
Queries the native database definition using

```sql
SHOW VARIABLES LIKE  'character_set_database';
```
and puts it back to `$link` in config.php using [mysqli.set-charset](https://www.php.net/manual/fr/mysqli.set-charset.php).

It fixes incorrect characters display such as:

![image](https://user-images.githubusercontent.com/17506424/113510034-e5344200-9558-11eb-90cd-d2962ab0d1b3.png)

![image](https://user-images.githubusercontent.com/17506424/113510048-fda45c80-9558-11eb-89d2-6a271e44bde6.png)
