### PR TITLE
check/uncheck all tables + title harmonization

### DIFF
--- a/core/tables.php
+++ b/core/tables.php
@@ -13,13 +13,21 @@
 <section class="pt-5">
     <div class="container">
         <div class="row">
-            <div class="col-md-12 mx-auto">
+        <div class="col-md-12 mx-auto">
+                <div class="text-center">
+                    <h4 class="mb-0">All available tables</h4>
+                </div>
+
+                <div class="row align-items-center mb-1">
+                    <div class="col-md-3 offset-md-9">
+                        <input type="checkbox" id="checkall">
+                        <label for="checkall">Check/uncheck all</label>
+                    </div>
+                </div>
+
+
                 <form class="form-horizontal" action="columns.php" method="post">
                     <fieldset>
-                        <div class="text-center mb-4">
-                            <h4>Available tables</h4>
-                        </div>
-
                         <?php
                         //Get all tables
                         $tablelist = array();
@@ -70,5 +78,13 @@
 <script src="https://code.jquery.com/jquery-3.5.1.min.js" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
 <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
 <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/js/bootstrap.min.js" integrity="sha384-OgVRvuATP1z7JjHLkuOU7Xw704+h835Lr+6QL9UvYjZE3Ipu6Tp75j7Bh/kR0JKI" crossorigin="anonymous"></script>
+<script>
+$(document).ready(function () {
+    $('#checkall').click(function(e) {
+        var chb = $('.form-horizontal').find('input[type="checkbox"]');
+        chb.prop('checked', !chb.prop('checked'));
+    });
+});
+</script>
 </body>
 </html>


### PR DESCRIPTION
As I added check/uncheck all columns in https://github.com/jan-vandenberg/cruddiy/pull/20 I assumed it would be nice to replicate the feature on tables selection:

![lmSQbkvAJC](https://user-images.githubusercontent.com/17506424/113616949-134b7c00-9656-11eb-9f84-fd91e25a4f2a.gif)

Also I noticed the title on `tables.php` was "_Available tables_" and on `columns.php` it was "_All available columns_", so I edited `tables.php` to "_All available tables_".