### PR TITLE
check if URL has params to prevent no params error

### DIFF
--- a/core/templates.php
+++ b/core/templates.php
@@ -51,7 +51,7 @@ $indexfile = <<<'EOT'
                     $protocol = $_SERVER['SERVER_PROTOCOL'];
                     $domain     = $_SERVER['HTTP_HOST'];
                     $script   = $_SERVER['SCRIPT_NAME'];
-                    $parameters   = $_SERVER['QUERY_STRING'];
+                    $parameters   = $GET ? $_SERVER['QUERY_STRING'] : "" ;
                     $protocol=strpos(strtolower($_SERVER['SERVER_PROTOCOL']),'https')
                                 === FALSE ? 'http' : 'https';
                     $currenturl = $protocol . '://' . $domain. $script . '?' . $parameters;


### PR DESCRIPTION
php raises a "Notice: Undefined index: QUERY_STRING" when index page has no query params