### PR TITLE
Fix PHP syntax error in generated -index.php pages

### DIFF
--- a/core/templates.php
+++ b/core/templates.php
@@ -51,7 +51,6 @@ $indexfile = <<<'EOT'
                     $domain   = $_SERVER['HTTP_HOST'];
                     $script   = $_SERVER['SCRIPT_NAME'];
                     $parameters   = $_GET ? $_SERVER['QUERY_STRING'] : "" ;
-                                === FALSE ? 'http' : 'https';
                     $protocol=($_SERVER['HTTPS'] == "on" ? "https" : "http");
                     $currenturl = $protocol . '://' . $domain. $script . '?' . $parameters;
 


### PR DESCRIPTION
The fix for https://github.com/jan-vandenberg/cruddiy/issues/54 resulted in the following PHP parse error in the generated index.php page:
"PHP Parse error:  syntax error, unexpected '===' (T_IS_IDENTICAL), expecting end of file in /var/www/html/app/test-index.php on line 51"