### PR TITLE
Add Foreign Key awareness and much more

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,1 @@
 core/app/
-core/sensor/
-/vendor
-composer.lock
-.php-cs-fixer.cache
-phptidy.php
-composer.json

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ core/sensor/
 composer.lock
 .php-cs-fixer.cache
 phptidy.php
+composer.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 core/app/
+core/sensor/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 core/app/
 core/sensor/
+/vendor
+composer.lock
+.php-cs-fixer.cache

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ core/sensor/
 /vendor
 composer.lock
 .php-cs-fixer.cache
+phptidy.php

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Cruddy kan php forms genereren voor Database operator (Create, Read, Update en D
 - [x] Laat colom comments zien bij velden
 - [ ] Comments van een tabel toevoegen aan de paginas.
 - [x] Laat SQL errors zien op het scherm. 
-- [ ] Foreign key doorverwijzen naar dat record.
+- [x] Foreign key doorverwijzen naar dat record.
 - [ ] Vanuit de foreign key, laat records zien die deze key gebuiken.
 - [x] Edit, delete knop maken op read pagina.
 - [x] Boolean / tinyint goed weergegeven. 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Cruddy kan php forms genereren voor Database operator (Create, Read, Update en D
 - [ ] Gebruik valuelist/datalist ipv select bij grote tabellen
 - [ ] Fix (lege) datums
 - [ ] Make css/js files choosable
-- [ ] Generate enum select statically at creation.
+- [x] Generate enum select statically at creation.
 - [ ] Replace 0/1 with True False?
 - [ ] Create an abstraction for the html syntax of columns in the read, edit and create pages.
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Cruddy kan php forms genereren voor Database operator (Create, Read, Update en D
 - [x] Kolommen in SQL met een (-) kunnen niet direct omgezet worden naar PHP variabelen.
 - [ ] Gebruik valuelist/datalist ipv select bij grote tabellen
 - [ ] Fix (lege) datums
+- [ ] Make css/js files choosable
+- [ ] Generate enum select statically at creation.
 
 ## Setup
 Clone deze repository in de root van WaterWeb, het zit al in de gitignore, dus waterweb heeft hier geen last van.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Cruddy kan php forms genereren voor Database operator (Create, Read, Update en D
 - [x] Formateer datum -> dd-mm-yyyy.
 - [x] Sorteer standaard op id?
 - [x] Count records met een count ipv `result.num_records()`.
-- [ ] Kolommen in SQL met een (-) kunnen niet direct omgezet worden naar PHP variabelen.
+- [x] Kolommen in SQL met een (-) kunnen niet direct omgezet worden naar PHP variabelen.
 
 ## Setup
 Clone deze repository in de root van WaterWeb, het zit al in de gitignore, dus waterweb heeft hier geen last van.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Cruddy kan php forms genereren voor Database operator (Create, Read, Update en D
 - [x] Formateer datum -> dd-mm-yyyy.
 - [x] Sorteer standaard op id?
 - [x] Count records met een count ipv `result.num_records()`.
+- [ ] Kolommen in SQL met een (-) kunnen niet direct omgezet worden naar PHP variabelen.
 
 ## Setup
 Clone deze repository in de root van WaterWeb, het zit al in de gitignore, dus waterweb heeft hier geen last van.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,16 @@
 # Crud forms generator for WaterWeb
-Cruddy kan php forms genereren voor Database operator (Create, Read, Update en Delete)
+Cruddy kan php forms genereren voor Database operator (Create, Read, Update en Delete). \
+(Geplande) nieuwe functionaliteiten t.o.v. cruddiy
+- [x] Laat colom comments zien bij velden
+- [ ] Comments van een tabel toevoegen aan de paginas.
+- [ ] Foreign key doorverwijzen naar dat record.
+- [ ] Vanuit de foreign key, laat records zien die deze key gebuiken.
+- [ ] Edit, delete knop maken op read pagina.
+- [ ] Boolean / tinyint.
+- [ ] SQL injections fixen.
+- [ ] Formateer datum -> dd-mm-yyyy.
+- [ ] Sorteer standaard op id of naam?
+- [ ] Count records met een count ipv `result.num_records()`.
 
 ## Setup
 Clone deze repository in de root van WaterWeb, het zit al in de gitignore, dus waterweb heeft hier geen last van.

--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ Cruddy kan php forms genereren voor Database operator (Create, Read, Update en D
 - [x] Add support for nullable columns.
 - [ ] Gebruik valuelist/datalist ipv select bij grote tabellen
 - [ ] Fix (lege) datums
-- [ ] Make css/js files choosable
+- [x] Make css/js files choosable
 - [x] Generate enum select statically at creation.
 - [x] Replace 0/1 with True False?
-- [ ] Create an abstraction for the html syntax of columns in the read, edit and create pages.
+- [x] Create an abstraction for the html syntax of columns in the read, edit and create pages.
 
 
 ## Setup

--- a/README.md
+++ b/README.md
@@ -1,41 +1,44 @@
-# Crud forms generator for WaterWeb
-Cruddy kan php forms genereren voor Database operator (Create, Read, Update en Delete). \
-(Geplande) nieuwe functionaliteiten t.o.v. cruddiy
-- [x] Show Column Comments from SQL as Tooltips for the column name.
-- [ ] Show SQL Table comments
-- [x] Show SQL errors when updating, creating or deleting. 
-- [x] Make foreign key references clickable.
-- [x] Preview foreign key references (using a tooltip?), also make it selectable (on creation) which columns appear in this reference.
-- [x] For a record that is referenced by other records, provide a link to these other table records.
-- [x] Add an update, delete and read button to the update, delete and read pages.
-- [x] Properly show Boolean / tinyint.
-- [x] Abstract the date view using a helper function.
-- [x] Fix PHP variables names with invalid characters, also escape SQL queries with `` to allow for all possible names.
-- [x] Add support for nullable columns.
-- [ ] Gebruik valuelist/datalist ipv select bij grote tabellen
-- [x] Make css/js files choosable
-- [x] Generate enum select statically at creation.
-- [x] Replace 0/1 with True False
-- [x] Create an abstraction for the html syntax of columns in the read, edit and create pages.
+# CRUDDIY
 
-
-## Setup
-Clone deze repository in de root van WaterWeb, het zit al in de gitignore, dus waterweb heeft hier geen last van.
-
-## Usage
-1. Ga naar je webhost/cruddiy, daar zijn instructies. 
-2. Zodra je nieuwe bestanden hebt. Vanuit de root, gebruik de volgende commands om nieuw gegenereerde crud bestanden over te zetten (Dit overschrijft de huidige)
-```
-cp -r cruddiy/core/app/ cruddiy/core/temp/
-rm  cruddiy/core/temp/config.php cruddiy/core/temp/error.php cruddiy/core/temp/helpers.php cruddiy/core/temp/index.php cruddiy/core/temp/navbar.php
-#docker-compose exec php var/www/public/cruddiy/vendor/bin/php-cs-fixer fix var/www/public/cruddiy/core/temp
-cp cruddiy/core/temp/* manager/modules/crud/
-rm -r cruddiy/core/temp
-```
-3. Gebruik de [format files](https://marketplace.visualstudio.com/items?itemName=jbockle.jbockle-format-files) extensie voor VScode om de bestanden te formateren.
-
-### CRUDDIY
-(FORK FROM CRUDDIY)
 Cruddiy is a free **no-code**  PHP Bootstrap CRUD generator with foreign key support.
 
 With Cruddiy you can easily generate some simple, but beautiful, PHP Bootstrap 4 CRUD pages (Create, Read, Update and Delete) with search, pagination and foreign key awareness.
+
+### Notes
+* Does not support MyISAM for Foreign Keys and Cascades. Will need InnoDB type ENGINE. MyISAM can be used, but Foreign Keys and Cascades will not be available.
+* PHP 7+ is recommended
+* Capable of string ID Primary Keys as well as integer ones.
+
+# How it works
+
+Cruddiy is written in PHP and will run on any PHP 7+ webserver. Just drop the folder with the code somewhere on your webserver and navigate to the folder (core/index.php). Cruddiy will first ask for your **database connection** information. Most of the time the database server is on the same machine (localhost): but it can be anywhere, and as long as you can connect to it, Cruddiy can generate the code for you.
+
+[![N|Cruddiy](https://j11g.com/cruddiy/bs4-cruddiy-start.png)](https://cruddiy.com)
+
+Once the connection parameters are entered correctly, Cruddiy will display all existing table relations (aka Foreign Keys). This only works for InnoDB tables.
+
+[![N|Cruddiy](https://j11g.com/cruddiy/bs4-cruddiy-relations.png)](https://cruddiy.com)
+
+It is possible to add or delete database relations and define actions (e.g. ON DELETE CASCADE).
+It is absolutely safe to SKIP this step (press the big green button) and continue if you please. However, having well-defined relations will result in prepopulated input fields on the create forms, and it will make sure child records are deleted correctly etc. When you use MyISAM you need to skip this step anyway.
+
+For the next step, Cruddiy will display all available **tables** in your database.
+
+[![N|Cruddiy](https://j11g.com/cruddiy/bs4-cruddiy-tables.png)](https://cruddiy.com)
+
+From there you can select tables you wish to generate CRUD pages for (maybe you just need a couple and not all tables in your database), and you can give them proper readable names (with capitalization or spaces etc.). Selecting a table will generate CRUD pages for that specific table. If you leave them unselected, NO pages will be created.
+After you have selected your tables, Cruddiy will present all **columns** from the previously selected tables. Again: you can give proper names and select which tablefields (columns) should be visible in the Index page. In this example you can see two tables, each have three columns selected to be visible on the index page. 
+
+[![N|Cruddiy](https://j11g.com/cruddiy/bs4-cruddiy-columns.png)](https://cruddiy.com)
+
+And that's it!
+
+Click Generate pages and Cruddiy will generate a complete PHP app for you in a separate folder, with config file, startpage and errorfile. You can directly navigate to your app, it will open in a new tab.
+
+[![N|Cruddiy](https://j11g.com/cruddiy/bs4-cruddiy-app.png)](https://cruddiy.com)
+
+This is the startpage. For every selected table, Cruddiy has created 5 pages: Index, Create, Read, Update and Delete. These pages are fully functional: the Index page has pagination and can be sorted by clicking on the columnname. You can also use the search box to quickly find records for that table.
+
+[![N|Cruddiy](https://j11g.com/cruddiy/bs4-cruddiy-app-index.png)](https://cruddiy.com)
+
+You can rename or move the generated 'app' folder anywhere. It is completely self-contained. And you can delete Cruddiy, it is not needed anymore. Or you can can run it many more times (use the back button in the browser), until you get your pages just the way you like them. Each time it will overwrite your existing app.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Cruddy kan php forms genereren voor Database operator (Create, Read, Update en D
 - [ ] SQL injections fixen.
 - [ ] Formateer datum -> dd-mm-yyyy.
 - [ ] Sorteer standaard op id of naam?
-- [ ] Count records met een count ipv `result.num_records()`.
+- [x] Count records met een count ipv `result.num_records()`.
 
 ## Setup
 Clone deze repository in de root van WaterWeb, het zit al in de gitignore, dus waterweb heeft hier geen last van.

--- a/README.md
+++ b/README.md
@@ -13,10 +13,9 @@ Cruddy kan php forms genereren voor Database operator (Create, Read, Update en D
 - [x] Fix PHP variables names with invalid characters, also escape SQL queries with `` to allow for all possible names.
 - [x] Add support for nullable columns.
 - [ ] Gebruik valuelist/datalist ipv select bij grote tabellen
-- [ ] Fix (lege) datums
 - [x] Make css/js files choosable
 - [x] Generate enum select statically at creation.
-- [x] Replace 0/1 with True False?
+- [x] Replace 0/1 with True False
 - [x] Create an abstraction for the html syntax of columns in the read, edit and create pages.
 
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Cruddy kan php forms genereren voor Database operator (Create, Read, Update en D
 - [ ] Show SQL Table comments
 - [x] Show SQL errors when updating, creating or deleting. 
 - [x] Make foreign key references clickable.
-- [ ] Preview foreign key references (using a tooltip?), also make it selectable (on creation) which columns appear in this reference.
+- [x] Preview foreign key references (using a tooltip?), also make it selectable (on creation) which columns appear in this reference.
 - [x] For a record that is referenced by other records, provide a link to these other table records.
 - [x] Add an update, delete and read button to the update, delete and read pages.
 - [x] Properly show Boolean / tinyint.
@@ -16,7 +16,7 @@ Cruddy kan php forms genereren voor Database operator (Create, Read, Update en D
 - [ ] Fix (lege) datums
 - [ ] Make css/js files choosable
 - [x] Generate enum select statically at creation.
-- [ ] Replace 0/1 with True False?
+- [x] Replace 0/1 with True False?
 - [ ] Create an abstraction for the html syntax of columns in the read, edit and create pages.
 
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ Cruddy kan php forms genereren voor Database operator (Create, Read, Update en D
 (Geplande) nieuwe functionaliteiten t.o.v. cruddiy
 - [x] Laat colom comments zien bij velden
 - [ ] Comments van een tabel toevoegen aan de paginas.
+- [ ] Laat SQL errors zien op het scherm. 
 - [ ] Foreign key doorverwijzen naar dat record.
 - [ ] Vanuit de foreign key, laat records zien die deze key gebuiken.
 - [ ] Edit, delete knop maken op read pagina.

--- a/README.md
+++ b/README.md
@@ -1,44 +1,21 @@
-# CRUDDIY
+# Crud forms generator for WaterWeb
+Cruddy kan php forms genereren voor Database operator (Create, Read, Update en Delete)
 
+## Setup
+Clone deze repository in de root van WaterWeb, het zit al in de gitignore, dus waterweb heeft hier geen last van.
+
+## Usage
+1. Ga naar je webhost/cruddiy, daar zijn instructies. 
+2. Zodra je nieuwe bestanden hebt. Vanuit de root, gebruik de volgende commands om nieuw gegenereerde crud bestanden over te zetten (Dit overschrijft de huidige)
+```
+cp -r cruddiy/core/app/ cruddiy/core/temp/
+rm  cruddiy/core/temp/config.php cruddiy/core/temp/error.php cruddiy/core/temp/helpers.php cruddiy/core/temp/index.php cruddiy/core/temp/navbar.php
+cp cruddiy/core/temp/* manager/modules/crud/
+rm -r cruddiy/core/temp
+```
+
+### CRUDDIY
+(FORK FROM CRUDDIY)
 Cruddiy is a free **no-code**  PHP Bootstrap CRUD generator with foreign key support.
 
 With Cruddiy you can easily generate some simple, but beautiful, PHP Bootstrap 4 CRUD pages (Create, Read, Update and Delete) with search, pagination and foreign key awareness.
-
-### Notes
-* Does not support MyISAM for Foreign Keys and Cascades. Will need InnoDB type ENGINE. MyISAM can be used, but Foreign Keys and Cascades will not be available.
-* PHP 7+ is recommended
-* Capable of string ID Primary Keys as well as integer ones.
-
-# How it works
-
-Cruddiy is written in PHP and will run on any PHP 7+ webserver. Just drop the folder with the code somewhere on your webserver and navigate to the folder (core/index.php). Cruddiy will first ask for your **database connection** information. Most of the time the database server is on the same machine (localhost): but it can be anywhere, and as long as you can connect to it, Cruddiy can generate the code for you.
-
-[![N|Cruddiy](https://j11g.com/cruddiy/bs4-cruddiy-start.png)](https://cruddiy.com)
-
-Once the connection parameters are entered correctly, Cruddiy will display all existing table relations (aka Foreign Keys). This only works for InnoDB tables.
-
-[![N|Cruddiy](https://j11g.com/cruddiy/bs4-cruddiy-relations.png)](https://cruddiy.com)
-
-It is possible to add or delete database relations and define actions (e.g. ON DELETE CASCADE).
-It is absolutely safe to SKIP this step (press the big green button) and continue if you please. However, having well-defined relations will result in prepopulated input fields on the create forms, and it will make sure child records are deleted correctly etc. When you use MyISAM you need to skip this step anyway.
-
-For the next step, Cruddiy will display all available **tables** in your database.
-
-[![N|Cruddiy](https://j11g.com/cruddiy/bs4-cruddiy-tables.png)](https://cruddiy.com)
-
-From there you can select tables you wish to generate CRUD pages for (maybe you just need a couple and not all tables in your database), and you can give them proper readable names (with capitalization or spaces etc.). Selecting a table will generate CRUD pages for that specific table. If you leave them unselected, NO pages will be created.
-After you have selected your tables, Cruddiy will present all **columns** from the previously selected tables. Again: you can give proper names and select which tablefields (columns) should be visible in the Index page. In this example you can see two tables, each have three columns selected to be visible on the index page. 
-
-[![N|Cruddiy](https://j11g.com/cruddiy/bs4-cruddiy-columns.png)](https://cruddiy.com)
-
-And that's it!
-
-Click Generate pages and Cruddiy will generate a complete PHP app for you in a separate folder, with config file, startpage and errorfile. You can directly navigate to your app, it will open in a new tab.
-
-[![N|Cruddiy](https://j11g.com/cruddiy/bs4-cruddiy-app.png)](https://cruddiy.com)
-
-This is the startpage. For every selected table, Cruddiy has created 5 pages: Index, Create, Read, Update and Delete. These pages are fully functional: the Index page has pagination and can be sorted by clicking on the columnname. You can also use the search box to quickly find records for that table.
-
-[![N|Cruddiy](https://j11g.com/cruddiy/bs4-cruddiy-app-index.png)](https://cruddiy.com)
-
-You can rename or move the generated 'app' folder anywhere. It is completely self-contained. And you can delete Cruddiy, it is not needed anymore. Or you can can run it many more times (use the back button in the browser), until you get your pages just the way you like them. Each time it will overwrite your existing app.

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ Cruddy kan php forms genereren voor Database operator (Create, Read, Update en D
 - [ ] Comments van een tabel toevoegen aan de paginas.
 - [x] Laat SQL errors zien op het scherm. 
 - [x] Foreign key doorverwijzen naar dat record.
-- [ ] Vanuit de foreign key, laat records zien die deze key gebuiken.
+- [x] Vanuit de foreign key, laat records zien die deze key gebuiken.
 - [x] Edit, delete knop maken op read pagina.
 - [x] Boolean / tinyint goed weergegeven. 
-- [ ] SQL injections fixen.
+- [x] SQL injections fixen.
 - [x] Formateer datum -> dd-mm-yyyy.
 - [x] Sorteer standaard op id?
 - [x] Count records met een count ipv `result.num_records()`.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Cruddy kan php forms genereren voor Database operator (Create, Read, Update en D
 - [ ] Foreign key doorverwijzen naar dat record.
 - [ ] Vanuit de foreign key, laat records zien die deze key gebuiken.
 - [ ] Edit, delete knop maken op read pagina.
-- [ ] Boolean / tinyint.
+- [ ] Boolean / tinyint goed weergegeven. 
 - [ ] SQL injections fixen.
 - [ ] Formateer datum -> dd-mm-yyyy.
 - [ ] Sorteer standaard op id of naam?

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ Cruddy kan php forms genereren voor Database operator (Create, Read, Update en D
 - [ ] Laat SQL errors zien op het scherm. 
 - [ ] Foreign key doorverwijzen naar dat record.
 - [ ] Vanuit de foreign key, laat records zien die deze key gebuiken.
-- [ ] Edit, delete knop maken op read pagina.
+- [x] Edit, delete knop maken op read pagina.
 - [ ] Boolean / tinyint goed weergegeven. 
 - [ ] SQL injections fixen.
 - [ ] Formateer datum -> dd-mm-yyyy.
-- [ ] Sorteer standaard op id of naam?
+- [x] Sorteer standaard op id?
 - [x] Count records met een count ipv `result.num_records()`.
 
 ## Setup

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Cruddy kan php forms genereren voor Database operator (Create, Read, Update en D
 - [x] Sorteer standaard op id?
 - [x] Count records met een count ipv `result.num_records()`.
 - [x] Kolommen in SQL met een (-) kunnen niet direct omgezet worden naar PHP variabelen.
+- [ ] Gebruik valuelist/datalist ipv select bij grote tabellen
+- [ ] Fix (lege) datums
 
 ## Setup
 Clone deze repository in de root van WaterWeb, het zit al in de gitignore, dus waterweb heeft hier geen last van.

--- a/README.md
+++ b/README.md
@@ -1,22 +1,24 @@
 # Crud forms generator for WaterWeb
 Cruddy kan php forms genereren voor Database operator (Create, Read, Update en Delete). \
 (Geplande) nieuwe functionaliteiten t.o.v. cruddiy
-- [x] Laat colom comments zien bij velden
-- [ ] Comments van een tabel toevoegen aan de paginas.
-- [x] Laat SQL errors zien op het scherm. 
-- [x] Foreign key doorverwijzen naar dat record.
-- [x] Vanuit de foreign key, laat records zien die deze key gebuiken.
-- [x] Edit, delete knop maken op read pagina.
-- [x] Boolean / tinyint goed weergegeven. 
-- [x] SQL injections fixen.
-- [x] Formateer datum -> dd-mm-yyyy.
-- [x] Sorteer standaard op id?
-- [x] Count records met een count ipv `result.num_records()`.
-- [x] Kolommen in SQL met een (-) kunnen niet direct omgezet worden naar PHP variabelen.
+- [x] Show Column Comments from SQL as Tooltips for the column name.
+- [ ] Show SQL Table comments
+- [x] Show SQL errors when updating, creating or deleting. 
+- [x] Make foreign key references clickable.
+- [ ] Preview foreign key references (using a tooltip?), also make it selectable (on creation) which columns appear in this reference.
+- [x] For a record that is referenced by other records, provide a link to these other table records.
+- [x] Add an update, delete and read button to the update, delete and read pages.
+- [x] Properly show Boolean / tinyint.
+- [x] Abstract the date view using a helper function.
+- [x] Fix PHP variables names with invalid characters, also escape SQL queries with `` to allow for all possible names.
+- [x] Add support for nullable columns.
 - [ ] Gebruik valuelist/datalist ipv select bij grote tabellen
 - [ ] Fix (lege) datums
 - [ ] Make css/js files choosable
 - [ ] Generate enum select statically at creation.
+- [ ] Replace 0/1 with True False?
+- [ ] Create an abstraction for the html syntax of columns in the read, edit and create pages.
+
 
 ## Setup
 Clone deze repository in de root van WaterWeb, het zit al in de gitignore, dus waterweb heeft hier geen last van.
@@ -27,10 +29,11 @@ Clone deze repository in de root van WaterWeb, het zit al in de gitignore, dus w
 ```
 cp -r cruddiy/core/app/ cruddiy/core/temp/
 rm  cruddiy/core/temp/config.php cruddiy/core/temp/error.php cruddiy/core/temp/helpers.php cruddiy/core/temp/index.php cruddiy/core/temp/navbar.php
-docker-compose exec php var/www/public/cruddiy/vendor/bin/php-cs-fixer fix var/www/public/cruddiy/core/temp
+#docker-compose exec php var/www/public/cruddiy/vendor/bin/php-cs-fixer fix var/www/public/cruddiy/core/temp
 cp cruddiy/core/temp/* manager/modules/crud/
 rm -r cruddiy/core/temp
 ```
+3. Gebruik de [format files](https://marketplace.visualstudio.com/items?itemName=jbockle.jbockle-format-files) extensie voor VScode om de bestanden te formateren.
 
 ### CRUDDIY
 (FORK FROM CRUDDIY)

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ Cruddy kan php forms genereren voor Database operator (Create, Read, Update en D
 - [ ] Foreign key doorverwijzen naar dat record.
 - [ ] Vanuit de foreign key, laat records zien die deze key gebuiken.
 - [x] Edit, delete knop maken op read pagina.
-- [ ] Boolean / tinyint goed weergegeven. 
+- [x] Boolean / tinyint goed weergegeven. 
 - [ ] SQL injections fixen.
-- [ ] Formateer datum -> dd-mm-yyyy.
+- [x] Formateer datum -> dd-mm-yyyy.
 - [x] Sorteer standaard op id?
 - [x] Count records met een count ipv `result.num_records()`.
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Clone deze repository in de root van WaterWeb, het zit al in de gitignore, dus w
 ```
 cp -r cruddiy/core/app/ cruddiy/core/temp/
 rm  cruddiy/core/temp/config.php cruddiy/core/temp/error.php cruddiy/core/temp/helpers.php cruddiy/core/temp/index.php cruddiy/core/temp/navbar.php
+docker-compose exec php var/www/public/cruddiy/vendor/bin/php-cs-fixer fix var/www/public/cruddiy/core/temp
 cp cruddiy/core/temp/* manager/modules/crud/
 rm -r cruddiy/core/temp
 ```

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Cruddy kan php forms genereren voor Database operator (Create, Read, Update en D
 (Geplande) nieuwe functionaliteiten t.o.v. cruddiy
 - [x] Laat colom comments zien bij velden
 - [ ] Comments van een tabel toevoegen aan de paginas.
-- [ ] Laat SQL errors zien op het scherm. 
+- [x] Laat SQL errors zien op het scherm. 
 - [ ] Foreign key doorverwijzen naar dat record.
 - [ ] Vanuit de foreign key, laat records zien die deze key gebuiken.
 - [x] Edit, delete knop maken op read pagina.

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,0 @@
-{
-    "config": {
-        "vendor-dir": "vendor"
-    },
-    "require": {
-        "friendsofphp/php-cs-fixer": "^3.16"
-    }
-}

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,8 @@
+{
+    "config": {
+        "vendor-dir": "vendor"
+    },
+    "require": {
+        "friendsofphp/php-cs-fixer": "^3.16"
+    }
+}

--- a/core/columns.php
+++ b/core/columns.php
@@ -16,10 +16,15 @@
                 </div>
 
                 <div class="col-md-10 mx-atuo text-right pr-5 ml-4">
-                    <input type="checkbox" id="checkall">
-                    <label for="checkall">Check/uncheck all</label>
                 </div>
 
+                <div class="mx-atuo text-right ml-4">
+                    <input type="checkbox" id="checkall-1" checked>
+                    <label for="checkall-1">Check/uncheck all</label>
+                    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+                    <input type="checkbox" id="checkall-2" checked>
+                    <label for="checkall-2">Check/uncheck all</label>
+                </div>
 
                 <form class="form-horizontal" action="generate.php" method="post">
                     <fieldset>
@@ -160,9 +165,12 @@
                                         <input type="hidden" name="'.$tablename.'columns['.$i.'][columnnullable]" value="'.$column_nullable.'"/>
                                         <input id="textinput_'.$tablename. '-'.$i.'"name="'. $tablename. 'columns['.$i.'][columndisplay]" type="text" placeholder="Display field name in frontend" class="form-control rounded-0">
                                     </div>
-                                    <div class="col-md-4">
-                                        <input type="checkbox"  name="'.$tablename.'columns['.$i.'][columnvisible]" id="checkboxes-'.$checked_tables_counter.'-'.$i.'" value="1">
+                                    <div class="col-md-2">
+                                        <input type="checkbox"  name="'.$tablename.'columns['.$i.'][columnvisible]" id="checkboxes-'.$checked_tables_counter.'-'.$i.'" value="1" checked>
                                 <label for="checkboxes-'.$checked_tables_counter.'-'.$i.'">Visible in overview?</label></div>
+                                    <div class="col-md-2">
+                                        <input type="checkbox"  name="'.$tablename.'columns['.$i.'][columninpreview]" id="checkboxes-'.$checked_tables_counter.'-'.$i.'-2" value="1" checked>
+                                <label for="checkboxes-'.$checked_tables_counter.'-'.$i.'-2">Visible in preview?</label></div>
                      </div></span>';
                                         $i++;
                                     }
@@ -205,8 +213,14 @@
 <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/js/bootstrap.min.js" integrity="sha384-OgVRvuATP1z7JjHLkuOU7Xw704+h835Lr+6QL9UvYjZE3Ipu6Tp75j7Bh/kR0JKI" crossorigin="anonymous"></script>
 <script>
 $(document).ready(function () {
-    $('#checkall').click(function(e) {
-        var chb = $('.form-horizontal').find('input[type="checkbox"]');
+    $('#checkall-1').click(function(e) {
+        var chb = $('.form-horizontal').find('input[name$="[columnvisible]"]');
+        chb.prop('checked', !chb.prop('checked'));
+    });
+});
+$(document).ready(function () {
+    $('#checkall-2').click(function(e) {
+        var chb = $('.form-horizontal').find('input[name$="[columninpreview]"]');
         chb.prop('checked', !chb.prop('checked'));
     });
 });

--- a/core/columns.php
+++ b/core/columns.php
@@ -62,6 +62,15 @@
                             mysqli_free_result($result);
                         }
 
+                        function get_col_comments($table,$column){
+                            global $link; 
+                            $sql = "SHOW FULL FIELDS FROM $table where FIELD ="."'".$column."'";
+                            $result = mysqli_query($link,$sql);
+                            $row = mysqli_fetch_assoc($result);
+                            return $row['Comment'] ;
+                            mysqli_free_result($result);
+                        }
+
                         function get_foreign_keys($table){
                             global $link;
                             global $db_name;
@@ -98,6 +107,7 @@
                                     while ($column = mysqli_fetch_array($result)) {
 
                                         $column_type = get_col_types($tablename,$column[0]);
+                                        $column_comment = get_col_comments($tablename,$column[0]);
 
                                         if (in_array ("$column[0]", $primary_keys)) {
                                             $primary = "🔑";
@@ -132,6 +142,7 @@
                                         <input type="hidden" name="'.$tablename.'columns['.$i.'][tabledisplay]" value="'.$tabledisplay.'"/>
                                         <input type="hidden" name="'.$tablename.'columns['.$i.'][columnname]" value="'.$column[0].'"/>
                                         <input type="hidden" name="'.$tablename.'columns['.$i.'][columntype]" value="'.$column_type.'"/>
+                                        <input type="hidden" name="'.$tablename.'columns['.$i.'][columncomment]" value="'.$column_comment.'"/>
                                         <input id="textinput_'.$tablename. '-'.$i.'"name="'. $tablename. 'columns['.$i.'][columndisplay]" type="text" placeholder="Display field name in frontend" class="form-control rounded-0">
                                     </div>
                                     <div class="col-md-4">

--- a/core/columns.php
+++ b/core/columns.php
@@ -139,9 +139,17 @@
                                             $fk = "";
                                         }
 
+                                        if ($column_nullable) {
+                                            $nb = "🫙";
+                                        }
+                                        else {
+                                            $nb = "";
+                                        }
+
+                                        echo "<span data-toggle='tooltip' data-placement='top' title='$column_comment'>";
                                         echo '<div class="row align-items-center mb-2">
                                     <div class="col-2 text-right"
-                                        <label class="col-form-label" for="'.$tablename.'">'. $primary . $auto . $fk . $column[0] . ' </label>
+                                        <label class="col-form-label" for="'.$tablename.'">'. $primary . $auto . $fk . $nb . $column[0] . ' </label>
                                     </div>
                                     <div class="col-md-6">
                                         <input type="hidden" name="'.$tablename.'columns['.$i.'][tablename]" value="'.$tablename.'"/>
@@ -155,7 +163,7 @@
                                     <div class="col-md-4">
                                         <input type="checkbox"  name="'.$tablename.'columns['.$i.'][columnvisible]" id="checkboxes-'.$checked_tables_counter.'-'.$i.'" value="1">
                                 <label for="checkboxes-'.$checked_tables_counter.'-'.$i.'">Visible in overview?</label></div>
-                     </div>';
+                     </div></span>';
                                         $i++;
                                     }
                                     $checked_tables_counter++;
@@ -201,6 +209,9 @@ $(document).ready(function () {
         var chb = $('.form-horizontal').find('input[type="checkbox"]');
         chb.prop('checked', !chb.prop('checked'));
     });
+});
+$(document).ready(function(){
+    $('[data-toggle="tooltip"]').tooltip();
 });
 </script>
 </body>

--- a/core/columns.php
+++ b/core/columns.php
@@ -59,7 +59,6 @@
                             $result = mysqli_query($link,$sql);
                             $row = mysqli_fetch_assoc($result);
                             return $row['Type'] ;
-                            mysqli_free_result($result);
                         }
 
                         function get_col_comments($table,$column){
@@ -68,7 +67,14 @@
                             $result = mysqli_query($link,$sql);
                             $row = mysqli_fetch_assoc($result);
                             return $row['Comment'] ;
-                            mysqli_free_result($result);
+                        }
+
+                        function get_col_nullable($table,$column){
+                            global $link; 
+                            $sql = "SHOW FULL FIELDS FROM $table where FIELD ="."'".$column."'";
+                            $result = mysqli_query($link,$sql);
+                            $row = mysqli_fetch_assoc($result);
+                            return ($row['Null'] == "YES") ? true : 0;
                         }
 
                         function get_foreign_keys($table){
@@ -85,7 +91,6 @@
                                 $fks[] = $row['Foreign Key'];
                             }
                             return $fks;
-                            mysqli_free_result($result);
                         }
 
                         $checked_tables_counter=0;
@@ -108,6 +113,7 @@
 
                                         $column_type = get_col_types($tablename,$column[0]);
                                         $column_comment = get_col_comments($tablename,$column[0]);
+                                        $column_nullable = get_col_nullable($tablename,$column[0]);
 
                                         if (in_array ("$column[0]", $primary_keys)) {
                                             $primary = "🔑";
@@ -143,6 +149,7 @@
                                         <input type="hidden" name="'.$tablename.'columns['.$i.'][columnname]" value="'.$column[0].'"/>
                                         <input type="hidden" name="'.$tablename.'columns['.$i.'][columntype]" value="'.$column_type.'"/>
                                         <input type="hidden" name="'.$tablename.'columns['.$i.'][columncomment]" value="'.$column_comment.'"/>
+                                        <input type="hidden" name="'.$tablename.'columns['.$i.'][columnnullable]" value="'.$column_nullable.'"/>
                                         <input id="textinput_'.$tablename. '-'.$i.'"name="'. $tablename. 'columns['.$i.'][columndisplay]" type="text" placeholder="Display field name in frontend" class="form-control rounded-0">
                                     </div>
                                     <div class="col-md-4">

--- a/core/generate.php
+++ b/core/generate.php
@@ -542,33 +542,34 @@ function generate($postdata) {
                         //ENUM types
                         case 2:
                         //Make sure on the update form that the previously selected type is also selected from the list
-                            $create_html [] = '<div class="form-group">
+                         
+                            $html = '<div class="form-group">
                                 <label>'.$columndisplay.'</label>
                                 <select name="'.$columnname.'" class="form-control" id="'.$columnname .'">';
                             if ($columns['columnnullable'])
                             {
-                                $create_html [] .= '<option value="">Null</option>';
+                                $html .= '<option value="">Null</option>';
                             }
-                            $create_html [] .=  '<?php
-                                            $sql_enum = "SELECT COLUMN_TYPE as AllPossibleEnumValues
-                                            FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = '. "'$tablename'" .'  AND COLUMN_NAME = '."'$columnname'" .'";
-                                            $result = mysqli_query($link, $sql_enum);
-                                            while($row = mysqli_fetch_array($result, MYSQLI_NUM)) {
-                                            preg_match(\'/enum\((.*)\)$/\', $row[0], $matches);
-                                            $vals = explode("," , $matches[1]);
-                                            foreach ($vals as $val){
-                                                $val = substr($val, 1);
-                                                $val = rtrim($val, "\'");
-                                                if ($val == $'.$columnname.'){
-                                                echo \'<option value="\' . $val . \'" selected="selected">\' . $val . \'</option>\';
-                                                } else
-                                                echo \'<option value="\' . $val . \'">\' . $val . \'</option>\';
-                                                        }
-                                            }?>';
 
-                            $create_html [] .= '</select>
+                            $sql_enum = "SELECT COLUMN_TYPE as AllPossibleEnumValues
+                            FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = '$tablename' AND COLUMN_NAME = '$columnname';";
+                            $result = mysqli_query($link, $sql_enum);
+                            $row = mysqli_fetch_array($result, MYSQLI_NUM);
+                            preg_match('/enum\((.*)\)$/', $row[0], $matches);
+                            $html .= "<?php \n\t\t\t\t\t\t\t \$enum_$columnname = array(" . $matches[1] . ");";
+                            $html .= "
+                                foreach (\$enum_$columnname as " . ' $val){
+                                    if ($val == $'.$columnname.'){
+                                    echo \'<option value="\' . $val . \'" selected="selected">\' . $val . \'</option>\';
+                                    } else
+                                    echo \'<option value="\' . $val . \'">\' . $val . \'</option>\';
+                                            }
+                            ?>';
+                            $html .= '</select>
                                 <span class="form-text"></span>
                                 </div>';
+                            $create_html [] = $html;
+                            unset($html);
                         break;
                         //VARCHAR
                         case 3:

--- a/core/generate.php
+++ b/core/generate.php
@@ -301,6 +301,8 @@ function generate($postdata) {
                     $column_id =  $columns['columnname'];
                 }
 
+                $type = column_type($columns['columntype']);
+
                 //INDEXFILE VARIABLES
                 //Get the columns visible in the index file
                 if (isset($columns['columnvisible'])){
@@ -321,7 +323,20 @@ function generate($postdata) {
 
                         $columns_available [] = $columnname;
                         $index_table_headers .= 'echo "<th><a href=?search=$search&sort='.$sort.'&order='.$columnname.'&sort=$sort>'.$columndisplay.'</th>";'."\n\t\t\t\t\t\t\t\t\t\t";
-                        $index_table_rows .= 'echo "<td>" . htmlspecialchars($row['. "'" . $columnname . "'" . '] ?? "") . "</td>";';
+                        
+                        // Display date in locale format
+                        if ($type == 7) // Date
+                        {
+                            $index_table_rows .= 'echo "<td>" . convert_date($row['. "'" . $columnname . "'" . ']) . "</td>";'."\n\t\t\t\t\t\t\t\t\t\t";
+                        }
+                        else if ($type == 8) // Datetime
+                        {
+                            $index_table_rows .= 'echo "<td>" . convert_datetime($row['. "'" . $columnname . "'" . ']) . "</td>";'."\n\t\t\t\t\t\t\t\t\t\t";
+                        }
+                        else
+                        {
+                            $index_table_rows .= 'echo "<td>" . htmlspecialchars($row['. "'" . $columnname . "'" . '] ?? "") . "</td>";'."\n\t\t\t\t\t\t\t\t\t\t";
+                        }
                         $i++;
                     }
                 }
@@ -329,8 +344,9 @@ function generate($postdata) {
 
             //DETAIL CREATE UPDATE AND DELETE pages variables
             foreach ( $_POST[$key] as $columns ) {
-                //print_r($columns);
                 if ($j < $total_columns) {
+
+                    $type = column_type($columns['columntype']);
 
                     if (isset($columns['columndisplay'])){
                         $columndisplay = $columns['columndisplay'];
@@ -374,8 +390,21 @@ function generate($postdata) {
                         $columnname = $columns['columnname'];
                         $read_records .= '<div class="form-group">
                             <h4>'.$columndisplay.'</h4>
-                            <p class="form-control-static"><?php echo htmlspecialchars($row["'.$columnname.'"] ?? ""); ?></p>
-                        </div>';
+                            <p class="form-control-static">';
+                        // Display date in locale format
+                        if ($type == 7) // Date
+                        {
+                            $read_records .= '<?php echo convert_date($row["'.$columnname.'"]); ?>';
+                        }
+                        else if ($type == 8) // Datetime
+                        {
+                            $read_records .= '<?php echo convert_datetime($row["'.$columnname.'"]); ?>';
+                        }
+                        else
+                        {
+                            $read_records .= '<?php echo htmlspecialchars($row["'.$columnname.'"] ?? ""); ?>';
+                        }
+                        $read_records .= '</p></div>';
 
                         $create_records .= "\$$columnname = \"\";\n";
                         $create_record = "\$$columnname";
@@ -439,9 +468,9 @@ function generate($postdata) {
                         }
 
                 // No Foreign Keys, just regular columns from here on
-                } else {
+                } else {                        
 
-                        $type = column_type($columns['columntype']);
+                        //$type = column_type($columns['columntype']);
 
                         switch($type) {
                         //TEXT

--- a/core/generate.php
+++ b/core/generate.php
@@ -296,6 +296,9 @@ function generate($postdata) {
             $max = count_index_colums($key)+1;
             $total_columns = count($_POST[$key]);
             $total_params = count($_POST[$key]);
+            
+            echo "KEYS VAN DE ARRAY";
+            print_r($_POST);
 
             //Specific INDEX page variables
             foreach ( $_POST[$key] as $columns ) {
@@ -335,6 +338,9 @@ function generate($postdata) {
                     }
                     if (empty($columns['columndisplay'])){
                         $columndisplay = $columns['columnname'];
+                    }
+                    if (isset($columns['columncomment'])){
+                        $columndisplay .= "(" . $columns['columncomment'] . ")";
                     }
 
                     if (!empty($columns['auto'])){

--- a/core/generate.php
+++ b/core/generate.php
@@ -316,7 +316,7 @@ function generate($postdata) {
                     $number_of_refs = mysqli_fetch_assoc(mysqli_query($link, $sql))["count"];
                     if ($number_of_refs > 0)
                     {
-                        $html .= \'<p><a href="'. $table . '-index.php?'. $column . '= \'. $row["'.$fk_column.'"]' . '.\'" class="btn btn-info">View \' . $number_of_refs . \' ' . $table . ' with '. $column . ' = \'. $row["'.$fk_column.'"] .\'</a></p></p>\';         
+                        $html .= \'<p><a href="'. $table . '-index.php?'. $column . '=\'. $row["'.$fk_column.'"]' . '.\'" class="btn btn-info">View \' . $number_of_refs . \' ' . $table . ' with '. $column . ' = \'. $row["'.$fk_column.'"] .\'</a></p></p>\';         
                     }';
                 }
             }
@@ -349,7 +349,7 @@ function generate($postdata) {
                         }
 
                         $columns_available [] = $columnname;
-                        $index_table_headers .= 'echo "<th><a href=?search=$search&sort='.$sort.'&order='.$columnname.'&sort=$sort>'.$columndisplay.'</th>";'."\n\t\t\t\t\t\t\t\t\t\t";
+                        $index_table_headers .= 'echo "<th><a href=?search=$search&order='.$columnname.'&sort=$sort$get_param>'.$columndisplay.'</th>";'."\n\t\t\t\t\t\t\t\t\t\t";
                         
                         // Display date in locale format
                         if(!empty($columns['fk'])){

--- a/core/generate.php
+++ b/core/generate.php
@@ -297,9 +297,6 @@ function generate($postdata) {
             $total_columns = count($_POST[$key]);
             $total_params = count($_POST[$key]);
             
-            echo "KEYS VAN DE ARRAY";
-            print_r($_POST);
-
             //Specific INDEX page variables
             foreach ( $_POST[$key] as $columns ) {
                 if (isset($columns['primary'])){
@@ -318,6 +315,10 @@ function generate($postdata) {
                             $columndisplay = $columns['columndisplay'];
                         } else {
                             $columndisplay = $columns['columnname'];
+                        }
+
+                        if (!empty($columns['columncomment'])){
+                            $columndisplay = "<span data-toggle='tooltip' data-placement='top' title='" . $columns['columncomment'] . "'>" . $columndisplay . '</span>';
                         }
 
                         $columns_available [] = $columnname;
@@ -339,8 +340,9 @@ function generate($postdata) {
                     if (empty($columns['columndisplay'])){
                         $columndisplay = $columns['columnname'];
                     }
-                    if (isset($columns['columncomment'])){
-                        $columndisplay .= "(" . $columns['columncomment'] . ")";
+
+                    if (!empty($columns['columncomment'])){
+                        $columndisplay = "<span data-toggle='tooltip' data-placement='top' title='" . $columns['columncomment'] . "'>" . $columndisplay . '</span>';
                     }
 
                     if (!empty($columns['auto'])){

--- a/core/generate.php
+++ b/core/generate.php
@@ -514,7 +514,11 @@ function generate($postdata) {
                 } else {                        
 
                         // Display date in locale format
-                        if ($type == 7) // Date
+                        if ($type == 4) // TinyInt / Bool
+                        {
+                            $read_records .= '<?php echo convert_bool($row["'.$columnname.'"]); ?>';
+                        }
+                        else if ($type == 7) // Date
                         {
                             $read_records .= '<?php echo convert_date($row["'.$columnname.'"]); ?>';
                         }

--- a/core/generate.php
+++ b/core/generate.php
@@ -342,10 +342,15 @@ function generate($postdata) {
                         $columndisplay = $columns['columnname'];
                     }
 
+                    if (!$columns['columnnullable'])
+                    {
+                        $columndisplay .= "*";
+                    }
+
                     if (!empty($columns['columncomment'])){
                         $columndisplay = "<span data-toggle='tooltip' data-placement='top' title='" . $columns['columncomment'] . "'>" . $columndisplay . '</span>';
                     }
-
+                    
                     if (!empty($columns['auto'])){
                         //Dont create html input field for auto-increment columns
                         $j++;
@@ -382,9 +387,12 @@ function generate($postdata) {
                         $create_sqlcolumns [] = $columnname;
                         $create_sql_params [] = "\$$columnname";
                         
-                        // Process POST vars that can be null
-                        // $create_postvars .= "$$columnname = trim(\$_POST[\"$columnname\"]);\n\t\t";
-                        $create_postvars .= "$$columnname = \$_POST[\"$columnname\"] == \"\" ? null : trim(\$_POST[\"$columnname\"]);\n\t\t";
+                        // Process POST vars that can be null differently
+                        if ($columns['columnnullable']){
+                            $create_postvars .= "$$columnname = \$_POST[\"$columnname\"] == \"\" ? null : trim(\$_POST[\"$columnname\"]);\n\t\t";
+                        } else {
+                            $create_postvars .= "$$columnname = trim(\$_POST[\"$columnname\"]);\n\t\t";
+                        }                        
                         
                         $update_sql_params [] = "$columnname".'=?';
                         $update_sql_id = "$column_id".'=?';

--- a/core/generate.php
+++ b/core/generate.php
@@ -311,10 +311,16 @@ function generate($postdata) {
                     $table = $row["Table"];
                     $fk_column = $row["FK Column"];
                     $column = $row["Column"];
-                    $foreign_key_references .= '<a href="'. $table . '-index.php?'.$column.'=<?php echo $_GET["'.$fk_column.'"];?>" class="btn btn-info">View '. $table .' with '. $column .' = <?php echo $_GET["'.$fk_column.'"];?></a></p>';
+                    $foreign_key_references .= '
+                    $sql = "SELECT COUNT(*) AS count FROM '. $table .' WHERE '. $column .' = ". $row["'.$fk_column.'"] . ";";
+                    $number_of_refs = mysqli_fetch_assoc(mysqli_query($link, $sql))["count"];
+                    if ($number_of_refs > 0)
+                    {
+                        $html .= \'<p><a href="'. $table . '-index.php?'. $column . '= \'. $row["'.$fk_column.'"]' . '.\'" class="btn btn-info">View \' . $number_of_refs . \' ' . $table . ' with '. $column . ' = \'. $row["'.$fk_column.'"] .\'</a></p></p>\';         
+                    }';
                 }
             }
-            $foreign_key_references = $foreign_key_references != "" ? "<h3>External references to this $tablename:</h3><p>$foreign_key_references</p>" : "";
+            $foreign_key_references = $foreign_key_references != "" ? '$html = "";' . $foreign_key_references . 'if ($html != "") {echo "<h3>References to this' . $tablename . ':</h3>" . $html;}' : "";
 
             //Specific INDEX page variables
             foreach ( $_POST[$key] as $columns ) {

--- a/core/generate.php
+++ b/core/generate.php
@@ -482,6 +482,10 @@ function generate($postdata) {
                             $index_table_rows .= 'echo "<td>" . get_fk_url($row["'.$columnname.'"], "'.$fk_table.'", "'.$fk_column.'", $row["'.$join_column_name.'"], '. $is_primary_ref .', true) . "</td>";'."\n\t\t\t\t\t\t\t\t\t\t";
                             }
                         }
+                        else if ($type == 1) // Text
+                        {
+                            $index_table_rows .= 'echo "<td>" . nl2br(htmlspecialchars($row['. "'" . $columnname . "'" . '] ?? "")) . "</td>";'."\n\t\t\t\t\t\t\t\t\t\t";
+                        }
                         else if ($type == 4) // TinyInt / Bool
                         {
                             $index_table_rows .= 'echo "<td>" . convert_bool($row['. "'" . $columnname . "'" . ']) . "</td>";'."\n\t\t\t\t\t\t\t\t\t\t";
@@ -638,7 +642,11 @@ function generate($postdata) {
                 } else {                        
 
                         // Display date in locale format
-                        if ($type == 4) // TinyInt / Bool
+                        if ($type == 1) // Text
+                        {
+                            $column_value = '<?php echo nl2br(htmlspecialchars($row["'.$columnname.'"] ?? "")); ?>';
+                        }
+                        else if ($type == 4) // TinyInt / Bool
                         {
                             $column_value = '<?php echo convert_bool($row["'.$columnname.'"]); ?>';
                         }
@@ -659,8 +667,8 @@ function generate($postdata) {
 
                         switch($type) {
                         //TEXT
-                        case 0:
-                            $column_input = '<input type="text" name="'. $columnname .'" id="'. $columnname .'" class="form-control" value="<?php echo '. $create_record. '; ?>">';
+                        case 1:
+                            $column_input = '<textarea name="'. $columnname .'" id="'. $columnname .'" class="form-control"><?php echo '. $create_record. '; ?></textarea>';
                         break;
 
                         //ENUM types
@@ -732,7 +740,7 @@ function generate($postdata) {
                         break;
 
                         default:
-                            $column_input = '<textarea name="'. $columnname .'" id="'. $columnname .'" class="form-control"><?php echo '. $create_record. ' ; ?></textarea>';
+                            $column_input = '<input type="text" name="'. $columnname .'" id="'. $columnname .'" class="form-control" value="<?php echo '. $create_record. '; ?>">';
                         break;
                         }
                     }

--- a/core/generate.php
+++ b/core/generate.php
@@ -30,9 +30,12 @@ $buttons_delimiter = '<!-- TABLE_BUTTONS -->';
 $CSS_REFS = '<link rel="stylesheet" href="css/style.css" type="text/css"/>
 <link rel="stylesheet" href="css/bootstrap.min.css" type="text/css"/>';
 
-$JS_REFS = '<script src="https://code.jquery.com/jquery-3.5.1.min.js" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
-<script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
-<script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/js/bootstrap.min.js" integrity="sha384-OgVRvuATP1z7JjHLkuOU7Xw704+h835Lr+6QL9UvYjZE3Ipu6Tp75j7Bh/kR0JKI" crossorigin="anonymous"></script>';
+// $JS_REFS = '<script src="https://code.jquery.com/jquery-3.5.1.min.js" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
+// <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
+// <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/js/bootstrap.min.js" integrity="sha384-OgVRvuATP1z7JjHLkuOU7Xw704+h835Lr+6QL9UvYjZE3Ipu6Tp75j7Bh/kR0JKI" crossorigin="anonymous"></script>';
+$JS_REFS = '<script src="js/jquery-3.5.1.min.js"></script>
+<script src="js/popper.min.js"></script>
+<script src="js/bootstrap.min.js"></script>';
     
 
 function column_type($columnname){

--- a/core/generate.php
+++ b/core/generate.php
@@ -452,10 +452,14 @@ function generate($postdata) {
 
                             $read_records .= '<?php echo get_fk_url($row["'.$columnname.'"], "'.$fk_table.'", "'.$fk_column.'"); ?>';
                             
-                            $create_html [] = '<div class="form-group">
+                            $html = '<div class="form-group">
                                 <label>'.$columndisplay.'</label>
-                                    <select class="form-control" id="'. $columnname .'" name="'. $columnname .'">
-                                    <?php
+                                    <select class="form-control" id="'. $columnname .'" name="'. $columnname .'">';
+                            if ($columns['columnnullable'])
+                            {
+                                $html .= '<option value="">Null</option>';
+                            }
+                            $html .= ' <?php
                                         $sql = "SELECT *,'. $fk_column .' FROM '. $fk_table . '";
                                         $result = mysqli_query($link, $sql);
                                         while($row = mysqli_fetch_array($result, MYSQLI_ASSOC)) {
@@ -472,6 +476,8 @@ function generate($postdata) {
                                     </select>
                                 <span class="form-text"><?php echo ' . $create_err_record . '; ?></span>
                             </div>';
+                            $create_html [] = $html;
+                            unset($html);
                         }
 
                 // No Foreign Keys, just regular columns from here on

--- a/core/generate.php
+++ b/core/generate.php
@@ -381,8 +381,11 @@ function generate($postdata) {
                         $create_err_record = "\$$columnname".'_err';
                         $create_sqlcolumns [] = $columnname;
                         $create_sql_params [] = "\$$columnname";
-                        $create_postvars .= "$$columnname = trim(\$_POST[\"$columnname\"]);\n\t\t";
-
+                        
+                        // Process POST vars that can be null
+                        // $create_postvars .= "$$columnname = trim(\$_POST[\"$columnname\"]);\n\t\t";
+                        $create_postvars .= "$$columnname = \$_POST[\"$columnname\"] == \"\" ? null : trim(\$_POST[\"$columnname\"]);\n\t\t";
+                        
                         $update_sql_params [] = "$columnname".'=?';
                         $update_sql_id = "$column_id".'=?';
                         $update_column_rows .= "$$columnname = htmlspecialchars(\$row[\"$columnname\"] ?? \"\");\n\t\t\t\t\t";

--- a/core/generate.php
+++ b/core/generate.php
@@ -501,7 +501,7 @@ function generate($postdata) {
                                         }
                                     ?>
                                     </select>
-                                <span class="form-text"><?php echo ' . $create_err_record . '; ?></span>
+                                <span class="form-text"></span>
                             </div>';
                             $create_html [] = $html;
                             unset($html);
@@ -532,7 +532,7 @@ function generate($postdata) {
                             $create_html [] = '<div class="form-group">
                                 <label>'.$columndisplay.'</label>
                                 <input type="text" name="'. $columnname .'" class="form-control" value="<?php echo '. $create_record. '; ?>">
-                                <span class="form-text"><?php echo ' . $create_err_record . '; ?></span>
+                                <span class="form-text"></span>
                             </div>';
                         break;
 
@@ -564,7 +564,7 @@ function generate($postdata) {
                                             }?>';
 
                             $create_html [] .= '</select>
-                                <span class="form-text"><?php echo ' . $create_err_record . '; ?></span>
+                                <span class="form-text"></span>
                                 </div>';
                         break;
                         //VARCHAR
@@ -575,7 +575,7 @@ function generate($postdata) {
                             $create_html [] = '<div class="form-group">
                                 <label>'.$columndisplay.'</label>
                                 <input type="text" name="'. $columnname .'" maxlength="'.$maxlength.'"class="form-control" value="<?php echo '. $create_record. '; ?>">
-                                <span class="form-text"><?php echo ' . $create_err_record . '; ?></span>
+                                <span class="form-text"></span>
                             </div>';
                         break;
                         //TINYINT (bool)
@@ -592,7 +592,7 @@ function generate($postdata) {
                             $html   .= '    <option value="0" <?php echo !' . $create_record . ' ? "selected": ""; ?> >False</option>';
                             $html   .= '    <option value="1" <?php echo ' . $create_record . ' ? "selected": ""; ?> >True</option>';
                             $html   .= '</select>
-                                <span class="form-text"><?php echo ' . $create_err_record . '; ?></span>
+                                <span class="form-text"></span>
                                 </div>';
                             $create_html [] = $html;
                             unset($html);
@@ -602,7 +602,7 @@ function generate($postdata) {
                             $create_html [] = '<div class="form-group">
                                 <label>'.$columndisplay.'</label>
                                 <input type="number" name="'. $columnname .'" class="form-control" value="<?php echo '. $create_record. '; ?>">
-                                <span class="form-text"><?php echo ' . $create_err_record . '; ?></span>
+                                <span class="form-text"></span>
                             </div>';
                         break;
 
@@ -611,7 +611,7 @@ function generate($postdata) {
                             $create_html [] = '<div class="form-group">
                                 <label>'.$columndisplay.'</label>
                                 <input type="number" name="'. $columnname .'" class="form-control" value="<?php echo '. $create_record. '; ?>" step="any">
-                                <span class="form-text"><?php echo ' . $create_err_record . '; ?></span>
+                                <span class="form-text"></span>
                             </div>';
                         break;
                         //DATE
@@ -619,7 +619,7 @@ function generate($postdata) {
                             $create_html [] = '<div class="form-group">
                                 <label>'.$columndisplay.'</label>
                                 <input type="date" name="'. $columnname .'" class="form-control" value="<?php echo '. $create_record. '; ?>">
-                                <span class="form-text"><?php echo ' . $create_err_record . '; ?></span>
+                                <span class="form-text"></span>
                             </div>';
                         break;
                         //DATETIME
@@ -627,7 +627,7 @@ function generate($postdata) {
                             $create_html [] = '<div class="form-group">
                                 <label>'.$columndisplay.'</label>
                                 <input type="datetime-local" name="'. $columnname .'" class="form-control" value="<?php echo date("Y-m-d\TH:i:s", strtotime('. $create_record. ')); ?>">
-                                <span class="form-text"><?php echo ' . $create_err_record . '; ?></span>
+                                <span class="form-text"></span>
                             </div>';
                         break;
 
@@ -635,7 +635,7 @@ function generate($postdata) {
                             $create_html [] = '<div class="form-group">
                                 <label>'.$columndisplay.'</label>
                                 <textarea name="'. $columnname .'" class="form-control"><?php echo '. $create_record. ' ; ?></textarea>
-                                <span class="form-text"><?php echo ' . $create_err_record . '; ?></span>
+                                <span class="form-text"></span>
                             </div>';
                         break;
                         }

--- a/core/generate.php
+++ b/core/generate.php
@@ -598,7 +598,7 @@ function generate($postdata) {
                         switch($type) {
                         //TEXT
                         case 0:
-                            $column_input = '<input type="text" name="'. $columnname .'" class="form-control" value="<?php echo '. $create_record. '; ?>">';
+                            $column_input = '<input type="text" name="'. $columnname .'" id="'. $columnname .'" class="form-control" value="<?php echo '. $create_record. '; ?>">';
                         break;
 
                         //ENUM types
@@ -633,14 +633,14 @@ function generate($postdata) {
                         case 3:
                             preg_match('#\((.*?)\)#', $columns['columntype'], $match);
                             $maxlength = $match[1];
-                            $column_input = '<input type="text" name="'. $columnname .'" maxlength="'.$maxlength.'"class="form-control" value="<?php echo '. $create_record. '; ?>">';
+                            $column_input = '<input type="text" name="'. $columnname .'" id="'. $columnname .'" maxlength="'.$maxlength.'"class="form-control" value="<?php echo '. $create_record. '; ?>">';
                         break;
 
                         //TINYINT (bool)
                         case 4:
                             $regex = "/'(.*?)'/";
                             preg_match_all( $regex , $columns['columntype'] , $enum_array );
-                            $html = '<select name="'.$columnname.'" class="form-control" id="'.$columnname .'">';
+                            $html = '<select name="'.$columnname.'" id="'. $columnname .'" class="form-control" id="'.$columnname .'">';
                                 if ($columns['columnnullable'])
                                 {
                                     $html .= '<option value="">Null</option>';
@@ -653,37 +653,44 @@ function generate($postdata) {
                         break;
                         //INT
                         case 5:
-                            $column_input = '<input type="number" name="'. $columnname .'" class="form-control" value="<?php echo '. $create_record. '; ?>">';
+                            $column_input = '<input type="number" name="'. $columnname .'" id="'. $columnname .'" class="form-control" value="<?php echo '. $create_record. '; ?>">';
                         break;
 
                         //DECIMAL
                         case 6:
-                            $column_input = '<input type="number" name="'. $columnname .'" class="form-control" value="<?php echo '. $create_record. '; ?>" step="any">';
+                            $column_input = '<input type="number" name="'. $columnname .'" id="'. $columnname .'" class="form-control" value="<?php echo '. $create_record. '; ?>" step="any">';
                         break;
                         //DATE
                         case 7:
-                            $column_input = '<input type="date" name="'. $columnname .'" class="form-control" value="<?php echo '. $create_record. '; ?>">';
+                            $column_input = '<input type="date" name="'. $columnname .'" id="'. $columnname .'" class="form-control" value="<?php echo '. $create_record. '; ?>">';
                         break;
                         //DATETIME
                         case 8:
-                            $column_input = '<input type="datetime-local" name="'. $columnname .'" class="form-control" value="<?php echo date("Y-m-d\TH:i:s", strtotime('. $create_record. ')); ?>">';
+                            $column_input = '<input type="datetime-local" name="'. $columnname .'" id="'. $columnname .'" class="form-control" value="<?php echo date("Y-m-d\TH:i:s", strtotime('. $create_record. ')); ?>">';
                         break;
 
                         default:
-                            $column_input = '<textarea name="'. $columnname .'" class="form-control"><?php echo '. $create_record. ' ; ?></textarea>';
+                            $column_input = '<textarea name="'. $columnname .'" id="'. $columnname .'" class="form-control"><?php echo '. $create_record. ' ; ?></textarea>';
                         break;
                         }
                     }
 
-                        $create_html [] = '<div class="form-group">
-                        <label>'.$columndisplay.'</label>
-                        '. $column_input .'
-                        <span class="form-text"></span>
-                    </div>';
-                        $read_records .= '<div class="form-group">
-                            <h4>'.$columndisplay.'</h4>
-                            <p class="form-control-static">' . $column_value .'</p></div>';
-                        $j++;
+                    $create_html [] = '<div class="form-group row">
+                    <label class="col-sm-4 col-form-label" for="'.$columnname.'">'.$columndisplay.'</label>
+                    <div class="col-sm-7">'. $column_input .'</div></div>';
+                    $read_records .= '<div class="form-group row">
+                        <div class="col-sm-3 font-weight-bold">'.$columndisplay.'</div>
+                        <div class="col-sm-7">'. $column_value .'</div></div>';
+                     
+                    // OLD LAYOUT    
+                    // $create_html [] = '<div class="form-group">
+                    // <label for="'.$columnname.'">'.$columndisplay.'</label>
+                    // '. $column_input .'</div>';
+                    // $read_records .= '<div class="form-group">
+                    //     <h4>'.$columndisplay.'</h4>
+                    //     <p class="form-control-static">' . $column_value .'</p></div>';
+                    
+                    $j++;
                     }
                 }
 

--- a/core/generate.php
+++ b/core/generate.php
@@ -26,16 +26,16 @@ $startpage_filename = "app/navbar.php";
 $forced_deletion = false;
 $buttons_delimiter = '<!-- TABLE_BUTTONS -->';
 
-//$CSS_REFS = '<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css" integrity="sha384-9aIt2nRpC12Uk9gS9baDl411NQApFmC26EwAOH8WgZl5MYYxFfc+NcPb1dKGj7Sk" crossorigin="anonymous">';
-$CSS_REFS = '<link rel="stylesheet" href="css/style.css" type="text/css"/>
-<link rel="stylesheet" href="css/bootstrap.min.css" type="text/css"/>';
+$CSS_REFS = '<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css" integrity="sha384-9aIt2nRpC12Uk9gS9baDl411NQApFmC26EwAOH8WgZl5MYYxFfc+NcPb1dKGj7Sk" crossorigin="anonymous">';
+// $CSS_REFS = '<link rel="stylesheet" href="css/style.css" type="text/css"/>
+// <link rel="stylesheet" href="css/bootstrap.min.css" type="text/css"/>';
 
-// $JS_REFS = '<script src="https://code.jquery.com/jquery-3.5.1.min.js" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
-// <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
-// <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/js/bootstrap.min.js" integrity="sha384-OgVRvuATP1z7JjHLkuOU7Xw704+h835Lr+6QL9UvYjZE3Ipu6Tp75j7Bh/kR0JKI" crossorigin="anonymous"></script>';
-$JS_REFS = '<script src="js/jquery-3.5.1.min.js"></script>
-<script src="js/popper.min.js"></script>
-<script src="js/bootstrap.min.js"></script>';
+$JS_REFS = '<script src="https://code.jquery.com/jquery-3.5.1.min.js" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
+<script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/js/bootstrap.min.js" integrity="sha384-OgVRvuATP1z7JjHLkuOU7Xw704+h835Lr+6QL9UvYjZE3Ipu6Tp75j7Bh/kR0JKI" crossorigin="anonymous"></script>';
+// $JS_REFS = '<script src="js/jquery-3.5.1.min.js"></script>
+// <script src="js/popper.min.js"></script>
+// <script src="js/bootstrap.min.js"></script>';
     
 
 function column_type($columnname){
@@ -424,7 +424,7 @@ function generate($postdata) {
             }
             $foreign_key_references = $foreign_key_references != "" ? '$html = "";' . $foreign_key_references . 'if ($html != "") {echo "<h3>References to this ' . $tablename . ':</h3>" . $html;}' : "";
 
-            //Specific INDEX page variables            
+            //Specific INDEX page variables
             foreach ( $_POST[$key] as $columns ) {
                 if (isset($columns['primary'])){
                     $column_id =  $columns['columnname'];
@@ -639,7 +639,7 @@ function generate($postdata) {
                         }
 
                 // No Foreign Keys, just regular columns from here on
-                } else {                        
+                } else {
 
                         // Display date in locale format
                         if ($type == 1) // Text
@@ -745,21 +745,21 @@ function generate($postdata) {
                         }
                     }
 
-                    $create_html [] = '<div class="form-group row">
-                    <label class="col-sm-4 col-form-label" for="'.$columnname.'">'.$columndisplay.'</label>
-                    <div class="col-sm-7">'. $column_input .'</div></div>';
-                    $read_records .= '<div class="form-group row">
-                        <div class="col-sm-3 font-weight-bold">'.$columndisplay.'</div>
-                        <div class="col-sm-7">'. $column_value .'</div></div>';
-                     
-                    // OLD LAYOUT    
-                    // $create_html [] = '<div class="form-group">
-                    // <label for="'.$columnname.'">'.$columndisplay.'</label>
-                    // '. $column_input .'</div>';
-                    // $read_records .= '<div class="form-group">
-                    //     <h4>'.$columndisplay.'</h4>
-                    //     <p class="form-control-static">' . $column_value .'</p></div>';
+                    // Regular layout
+                    $create_html [] = '<div class="form-group">
+                    <label for="'.$columnname.'">'.$columndisplay.'</label>
+                    '. $column_input .'</div>';
+                    $read_records .= '<div class="form-group">
+                        <h4>'.$columndisplay.'</h4>
+                        <p class="form-control-static">' . $column_value .'</p></div>';
                     
+                    // Different Layout
+                    // $create_html [] = '<div class="form-group row">
+                    // <label class="col-sm-4 col-form-label" for="'.$columnname.'">'.$columndisplay.'</label>
+                    // <div class="col-sm-7">'. $column_input .'</div></div>';
+                    // $read_records .= '<div class="form-group row">
+                    //     <div class="col-sm-3 font-weight-bold">'.$columndisplay.'</div>
+                    //     <div class="col-sm-7">'. $column_value .'</div></div>';
                     $j++;
                     }
                 }

--- a/core/generate.php
+++ b/core/generate.php
@@ -197,7 +197,7 @@ function generate_delete($tablename, $column_id){
     echo "Generating $tablename Delete file<br><br>";
 }
 
-function generate_create($tablename,$create_records, $create_err_records, $create_sqlcolumns, $create_numberofparams, $create_sql_params, $create_html, $create_postvars) {
+function generate_create($tablename,$create_records, $create_err_records, $create_sqlcolumns, $column_id, $create_numberofparams, $create_sql_params, $create_html, $create_postvars) {
     global $createfile;
     $step0 = str_replace("{TABLE_NAME}", $tablename, $createfile);
     $step1 = str_replace("{CREATE_RECORDS}", $create_records, $step0);
@@ -207,7 +207,8 @@ function generate_create($tablename,$create_records, $create_err_records, $creat
     $step5 = str_replace("{CREATE_SQL_PARAMS}", $create_sql_params, $step4 );
     $step6 = str_replace("{CREATE_HTML}", $create_html, $step5);
     $step7 = str_replace("{CREATE_POST_VARIABLES}", $create_postvars, $step6);
-    if (!file_put_contents("app/".$tablename."-create.php", $step7, LOCK_EX)) {
+    $step8 = str_replace("{COLUMN_ID}", $column_id, $step7);
+    if (!file_put_contents("app/".$tablename."-create.php", $step8, LOCK_EX)) {
         die("Unable to open file!");
     }
     echo "Generating $tablename Create file<br>";
@@ -587,7 +588,7 @@ function generate($postdata) {
                     generate_error();
                     generate_startpage();
                     generate_index($tablename,$tabledisplay,$index_table_headers,$index_table_rows,$column_id, $columns_available,$index_sql_search);
-                    generate_create($tablename,$create_records, $create_err_records, $create_sqlcolumns, $create_numberofparams, $create_sql_params, $create_html, $create_postvars);
+                    generate_create($tablename,$create_records, $create_err_records, $create_sqlcolumns, $column_id, $create_numberofparams, $create_sql_params, $create_html, $create_postvars);
                     generate_read($tablename,$column_id,$read_records);
                     generate_update($tablename, $create_records, $create_err_records, $create_postvars, $column_id, $create_html, $update_sql_params, $update_sql_id, $update_column_rows, $update_sql_columns);
                     generate_delete($tablename,$column_id);

--- a/core/generate.php
+++ b/core/generate.php
@@ -58,6 +58,16 @@ function column_type($columnname){
     }
 }
 
+function is_primary_key($t, $c){
+    $cols = $_POST[$t . 'columns'];
+    foreach($cols as $col) {
+        if (isset($col['primary']) && $col['columnname'] == $c){
+            return 1;
+        }
+    }
+    return 0;
+}
+
 function get_sql_concat_select($copy_columns, $table, $name){
     $array = $copy_columns;
     foreach($array as $key => $c)
@@ -409,7 +419,8 @@ function generate($postdata) {
                                     $fk_column = $row["FK Column"];
                                 }
                             $join_column_name = $columnname . $fk_table . $fk_column;
-                            $index_table_rows .= 'echo "<td>" . get_fk_url($row["'.$columnname.'"], "'.$fk_table.'", "'.$fk_column.'", $row["'.$join_column_name.'"]) . "</td>";'."\n\t\t\t\t\t\t\t\t\t\t";
+                            $is_primary_ref = is_primary_key($fk_table, $fk_column);
+                            $index_table_rows .= 'echo "<td>" . get_fk_url($row["'.$columnname.'"], "'.$fk_table.'", "'.$fk_column.'", $row["'.$join_column_name.'"], '. $is_primary_ref .', true) . "</td>";'."\n\t\t\t\t\t\t\t\t\t\t";
                             }
                         }
                         else if ($type == 7) // Date
@@ -536,7 +547,10 @@ function generate($postdata) {
                             $join_clauses .= "\n\t\t\tLEFT JOIN `$fk_table` AS `$join_name` ON `$join_name`.`$fk_column` = `$tablename`.`$columnname`";
                             $join_columns .= get_sql_concat_select($preview_columns[$fk_table], $join_name, $join_column_name);
                             
-                            $read_records .= '<?php echo get_fk_url($row["'.$columnname.'"], "'.$fk_table.'", "'.$fk_column.'", $row["'.$join_column_name.'"]); ?>';
+
+                            $is_primary_ref = is_primary_key($fk_table, $fk_column);
+
+                            $read_records .= '<?php echo get_fk_url($row["'.$columnname.'"], "'.$fk_table.'", "'.$fk_column.'", $row["'.$join_column_name.'"], '. $is_primary_ref .', false); ?>';
 
                             $html .= ' <?php
                                         $sql = "SELECT '. $fk_columns_select .', `'. $fk_column .'` FROM `'. $fk_table . '` ORDER BY '. $fk_columns_select .'";

--- a/core/generate.php
+++ b/core/generate.php
@@ -482,6 +482,10 @@ function generate($postdata) {
                             $index_table_rows .= 'echo "<td>" . get_fk_url($row["'.$columnname.'"], "'.$fk_table.'", "'.$fk_column.'", $row["'.$join_column_name.'"], '. $is_primary_ref .', true) . "</td>";'."\n\t\t\t\t\t\t\t\t\t\t";
                             }
                         }
+                        else if ($type == 4) // TinyInt / Bool
+                        {
+                            $index_table_rows .= 'echo "<td>" . convert_bool($row['. "'" . $columnname . "'" . ']) . "</td>";'."\n\t\t\t\t\t\t\t\t\t\t";
+                        }
                         else if ($type == 7) // Date
                         {
                             $index_table_rows .= 'echo "<td>" . convert_date($row['. "'" . $columnname . "'" . ']) . "</td>";'."\n\t\t\t\t\t\t\t\t\t\t";
@@ -601,6 +605,11 @@ function generate($postdata) {
                             $join_clauses .= "\n\t\t\tLEFT JOIN `$fk_table` AS `$join_name` ON `$join_name`.`$fk_column` = `$tablename`.`$columnname`";
                             $join_columns .= get_sql_concat_select($preview_columns[$fk_table], $join_name, $join_column_name);
                             
+                            // Add the new columns to the search concat
+                            foreach($preview_columns[$fk_table] as $key => $c)
+                            {
+                                $index_sql_search [] = '`'. $join_name .'`.`'. $preview_columns[$fk_table][$key] .'`'; 
+                            }
 
                             $is_primary_ref = is_primary_key($fk_table, $fk_column);
 
@@ -751,13 +760,13 @@ function generate($postdata) {
 
                     $update_sql_columns = $create_sql_params;
                     $update_sql_columns [] = "\$$column_id";
-                    $update_sql_columns = implode(",", $update_sql_columns);
+                    $update_sql_columns = implode(", ", $update_sql_columns);
 
-                    $index_sql_search = implode(",", $index_sql_search);
+                    $index_sql_search = implode(", ", $index_sql_search);
                     $create_numberofparams = array_fill(0, $total_params, '?');
-                    $create_numberofparams = implode(",", $create_numberofparams);
-                    $create_sqlcolumns = implode(",", $create_sqlcolumns);
-                    $create_sql_params = implode(",", $create_sql_params);
+                    $create_numberofparams = implode(", ", $create_numberofparams);
+                    $create_sqlcolumns = implode(", ", $create_sqlcolumns);
+                    $create_sql_params = implode(", ", $create_sql_params);
                     $create_html = implode("\n\t\t\t\t\t\t", $create_html);
 
                     $update_sql_params = implode(",", $update_sql_params);

--- a/core/generate.php
+++ b/core/generate.php
@@ -736,7 +736,7 @@ function generate($postdata) {
                         break;
                         //DATETIME
                         case 8:
-                            $column_input = '<input type="datetime-local" name="'. $columnname .'" id="'. $columnname .'" class="form-control" value="<?php echo date("Y-m-d\TH:i:s", strtotime('. $create_record. ')); ?>">';
+                            $column_input = '<input type="datetime-local" name="'. $columnname .'" id="'. $columnname .'" class="form-control" value="<?php echo empty('. $create_record. ') ? "" : date("Y-m-d\TH:i:s", strtotime('. $create_record. ')); ?>">';
                         break;
 
                         default:

--- a/core/generate.php
+++ b/core/generate.php
@@ -37,11 +37,8 @@ function column_type($columnname){
         case (preg_match("/varchar/i", $columnname) ? true : false) :
             return 3;
         break;
-            //Tinyint needs work to be selectable from dropdown list
-            //So for now a tinyint will be just a input field (in Create)
-            //and a prefilled input field (in Update).
         case (preg_match("/tinyint\(1\)/i", $columnname) ? true : false) :
-            return 5;
+            return 4;
         break;
         case (preg_match("/int/i", $columnname) ? true : false) :
             return 5;
@@ -462,6 +459,10 @@ function generate($postdata) {
                             $create_html [] = '<div class="form-group">
                                 <label>'.$columndisplay.'</label>
                                 <select name="'.$columnname.'" class="form-control" id="'.$columnname .'">';
+                            if ($columns['columnnullable'])
+                            {
+                                $create_html [] .= '<option value="">Null</option>';
+                            }
                             $create_html [] .=  '<?php
                                             $sql_enum = "SELECT COLUMN_TYPE as AllPossibleEnumValues
                                             FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = '. "'$tablename'" .'  AND COLUMN_NAME = '."'$columnname'" .'";
@@ -494,19 +495,24 @@ function generate($postdata) {
                                 <span class="form-text"><?php echo ' . $create_err_record . '; ?></span>
                             </div>';
                         break;
-                        //TINYINT - Will never hit. Needs work.
+                        //TINYINT (bool)
                         case 4:
                             $regex = "/'(.*?)'/";
                             preg_match_all( $regex , $columns['columntype'] , $enum_array );
-
-                            $create_html [] = '<div class="form-group">
+                            $html = '<div class="form-group">
                                 <label>'.$columndisplay.'</label>
                                 <select name="'.$columnname.'" class="form-control" id="'.$columnname .'">';
-                                        $create_html [] .= '    <option value="0">0</option>';
-                                        $create_html [] .= '    <option value="1">1</option>';
-                            $create_html [] .= '</select>
+                                if ($columns['columnnullable'])
+                                {
+                                    $html .= '<option value="">Null</option>';
+                                }
+                            $html   .= '    <option value="0" <?php echo !' . $create_record . ' ? "selected": ""; ?> >False</option>';
+                            $html   .= '    <option value="1" <?php echo ' . $create_record . ' ? "selected": ""; ?> >True</option>';
+                            $html   .= '</select>
                                 <span class="form-text"><?php echo ' . $create_err_record . '; ?></span>
                                 </div>';
+                            $create_html [] = $html;
+                            unset($html);
                         break;
                         //INT
                         case 5:

--- a/core/generate.php
+++ b/core/generate.php
@@ -323,7 +323,7 @@ function generate($postdata) {
 
                         $columns_available [] = $columnname;
                         $index_table_headers .= 'echo "<th><a href=?search=$search&sort='.$sort.'&order='.$columnname.'&sort=$sort>'.$columndisplay.'</th>";'."\n\t\t\t\t\t\t\t\t\t\t";
-                        $index_table_rows .= 'echo "<td>" . htmlspecialchars($row['. "'" . $columnname . "'" . ']) . "</td>";';
+                        $index_table_rows .= 'echo "<td>" . htmlspecialchars($row['. "'" . $columnname . "'" . '] ?? "") . "</td>";';
                         $i++;
                     }
                 }
@@ -371,7 +371,7 @@ function generate($postdata) {
                         $columnname = $columns['columnname'];
                         $read_records .= '<div class="form-group">
                             <h4>'.$columndisplay.'</h4>
-                            <p class="form-control-static"><?php echo htmlspecialchars($row["'.$columnname.'"]); ?></p>
+                            <p class="form-control-static"><?php echo htmlspecialchars($row["'.$columnname.'"] ?? ""); ?></p>
                         </div>';
 
                         $create_records .= "\$$columnname = \"\";\n";
@@ -384,7 +384,7 @@ function generate($postdata) {
 
                         $update_sql_params [] = "$columnname".'=?';
                         $update_sql_id = "$column_id".'=?';
-                        $update_column_rows .= "$$columnname = htmlspecialchars(\$row[\"$columnname\"]);\n\t\t\t\t\t";
+                        $update_column_rows .= "$$columnname = htmlspecialchars(\$row[\"$columnname\"] ?? \"\");\n\t\t\t\t\t";
 
 
                         //Foreign Key

--- a/core/generate.php
+++ b/core/generate.php
@@ -26,6 +26,15 @@ $startpage_filename = "app/navbar.php";
 $forced_deletion = false;
 $buttons_delimiter = '<!-- TABLE_BUTTONS -->';
 
+//$CSS_REFS = '<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css" integrity="sha384-9aIt2nRpC12Uk9gS9baDl411NQApFmC26EwAOH8WgZl5MYYxFfc+NcPb1dKGj7Sk" crossorigin="anonymous">';
+$CSS_REFS = '<link rel="stylesheet" href="css/style.css" type="text/css"/>
+<link rel="stylesheet" href="css/bootstrap.min.css" type="text/css"/>';
+
+$JS_REFS = '<script src="https://code.jquery.com/jquery-3.5.1.min.js" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
+<script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/js/bootstrap.min.js" integrity="sha384-OgVRvuATP1z7JjHLkuOU7Xw704+h835Lr+6QL9UvYjZE3Ipu6Tp75j7Bh/kR0JKI" crossorigin="anonymous"></script>';
+    
+
 function column_type($columnname){
     switch ($columnname) {
         case (preg_match("/text/i", $columnname) ? true : false) :
@@ -88,15 +97,27 @@ function get_sql_select($copy_columns){
 
 function generate_error(){
     global $errorfile;
-    if (!file_put_contents("app/error.php", $errorfile, LOCK_EX)) {
+    global $CSS_REFS;
+    global $JS_REFS;
+
+    $prestep1 = str_replace("{CSS_REFS}", $CSS_REFS, $errorfile);
+    $prestep2 = str_replace("{JS_REFS}", $JS_REFS, $prestep1);
+
+    if (!file_put_contents("app/error.php", $prestep2, LOCK_EX)) {
         die("Unable to open file!");
     }
     echo "Generating Error file<br>";
 }
 
 function generate_startpage(){
-    global $startfile; 
-    if (!file_put_contents("app/index.php", $startfile, LOCK_EX)) {
+    global $startfile;
+    global $CSS_REFS;
+    global $JS_REFS;
+
+    $prestep1 = str_replace("{CSS_REFS}", $CSS_REFS, $startfile);
+    $prestep2 = str_replace("{JS_REFS}", $JS_REFS, $prestep1);
+
+    if (!file_put_contents("app/index.php", $prestep2, LOCK_EX)) {
         die("Unable to open file!");
     }
     echo "Generating main index file.<br>";
@@ -183,9 +204,14 @@ function append_links_to_navbar($navbarfile, $start_page, $startpage_filename, $
 function generate_index($tablename,$tabledisplay,$index_table_headers,$index_table_rows,$column_id, $columns_available, $index_sql_search, $join_columns, $join_clauses) {
     global $indexfile;
     global $appname;
+    global $CSS_REFS;
+    global $JS_REFS;
+
+    $prestep1 = str_replace("{CSS_REFS}", $CSS_REFS, $indexfile);
+    $prestep2 = str_replace("{JS_REFS}", $JS_REFS, $prestep1);
 
     $columns_available = implode("', '", $columns_available);
-    $step1 = str_replace("{TABLE_NAME}", $tablename, $indexfile);
+    $step1 = str_replace("{TABLE_NAME}", $tablename, $prestep2);
     $step2 = str_replace("{TABLE_DISPLAY}", $tabledisplay, $step1);
     $step3 = str_replace("{INDEX_TABLE_HEADERS}", $index_table_headers, $step2 );
     $step4 = str_replace("{INDEX_TABLE_ROWS}", $index_table_rows, $step3 );
@@ -204,7 +230,13 @@ function generate_index($tablename,$tabledisplay,$index_table_headers,$index_tab
 
 function generate_read($tablename, $column_id, $read_records, $foreign_key_references, $join_columns, $join_clauses){
     global $readfile;
-    $step0 = str_replace("{TABLE_NAME}", $tablename, $readfile);
+    global $CSS_REFS;
+    global $JS_REFS;
+
+    $prestep1 = str_replace("{CSS_REFS}", $CSS_REFS, $readfile);
+    $prestep2 = str_replace("{JS_REFS}", $JS_REFS, $prestep1);
+
+    $step0 = str_replace("{TABLE_NAME}", $tablename, $prestep2);
     $step1 = str_replace("{TABLE_ID}", $column_id, $step0);
     $step2 = str_replace("{RECORDS_READ_FORM}", $read_records, $step1 );
     $step3 = str_replace("{FOREIGN_KEY_REFS}", $foreign_key_references, $step2 );
@@ -218,7 +250,13 @@ function generate_read($tablename, $column_id, $read_records, $foreign_key_refer
 
 function generate_delete($tablename, $column_id){
     global $deletefile;
-    $step0 = str_replace("{TABLE_NAME}", $tablename, $deletefile);
+    global $CSS_REFS;
+    global $JS_REFS;
+
+    $prestep1 = str_replace("{CSS_REFS}", $CSS_REFS, $deletefile);
+    $prestep2 = str_replace("{JS_REFS}", $JS_REFS, $prestep1);
+
+    $step0 = str_replace("{TABLE_NAME}", $tablename, $prestep2);
     $step1 = str_replace("{TABLE_ID}", $column_id, $step0);
     if (!file_put_contents("app/".$tablename."-delete.php", $step1, LOCK_EX)) {
         die("Unable to open file!");
@@ -228,7 +266,13 @@ function generate_delete($tablename, $column_id){
 
 function generate_create($tablename,$create_records, $create_err_records, $create_sqlcolumns, $column_id, $create_numberofparams, $create_sql_params, $create_html, $create_postvars) {
     global $createfile;
-    $step0 = str_replace("{TABLE_NAME}", $tablename, $createfile);
+    global $CSS_REFS;
+    global $JS_REFS;
+
+    $prestep1 = str_replace("{CSS_REFS}", $CSS_REFS, $createfile);
+    $prestep2 = str_replace("{JS_REFS}", $JS_REFS, $prestep1);
+
+    $step0 = str_replace("{TABLE_NAME}", $tablename, $prestep2);
     $step1 = str_replace("{CREATE_RECORDS}", $create_records, $step0);
     $step2 = str_replace("{CREATE_ERR_RECORDS}", $create_err_records, $step1);
     $step3 = str_replace("{CREATE_COLUMN_NAMES}", $create_sqlcolumns, $step2);
@@ -245,7 +289,13 @@ function generate_create($tablename,$create_records, $create_err_records, $creat
 
 function generate_update($tablename, $create_records, $create_err_records, $create_postvars, $column_id, $create_html, $update_sql_params, $update_sql_id, $update_column_rows, $update_sql_columns){
     global $updatefile;
-    $step0 = str_replace("{TABLE_NAME}", $tablename, $updatefile);
+    global $CSS_REFS;
+    global $JS_REFS;
+
+    $prestep1 = str_replace("{CSS_REFS}", $CSS_REFS, $updatefile);
+    $prestep2 = str_replace("{JS_REFS}", $JS_REFS, $prestep1);
+
+    $step0 = str_replace("{TABLE_NAME}", $tablename, $prestep2);
     $step1 = str_replace("{CREATE_RECORDS}", $create_records, $step0);
     $step2 = str_replace("{CREATE_ERR_RECORDS}", $create_err_records, $step1);
     $step3 = str_replace("{COLUMN_ID}", $column_id, $step2);

--- a/core/helpers.php
+++ b/core/helpers.php
@@ -78,4 +78,10 @@ function get_columns_attributes($table_name, $column) {
         return $row;
     }
 }
+
+function print_error_if_exists($error) {
+    if(isset($error)){
+        echo "<div class='alert alert-danger' role='alert'>$error</div>";
+    }
+}
 ?>

--- a/core/helpers.php
+++ b/core/helpers.php
@@ -1,6 +1,7 @@
 <?php
 // retrieves and enhances postdata table keys and values on CREATE and UPDATE events
-function parse_columns($table_name, $postdata) {
+function parse_columns($table_name, $postdata)
+{
     global $link;
     $vars = array();
 
@@ -10,10 +11,9 @@ function parse_columns($table_name, $postdata) {
     // get all columns, including the ones not sent by the CRUD form
     $sql = "SELECT COLUMN_NAME, DATA_TYPE, IS_NULLABLE, COLUMN_DEFAULT, EXTRA
             FROM INFORMATION_SCHEMA.COLUMNS
-            WHERE table_name = '".$table_name."'";
-    $result = mysqli_query($link,$sql);
-    while($row = mysqli_fetch_assoc($result))
-    {
+            WHERE table_name = '" . $table_name . "'";
+    $result = mysqli_query($link, $sql);
+    while ($row = mysqli_fetch_assoc($result)) {
 
         $debug = 0;
         if ($debug) {
@@ -28,7 +28,7 @@ function parse_columns($table_name, $postdata) {
             echo "</pre>";
         }
 
-        switch($row['DATA_TYPE']) {
+        switch ($row['DATA_TYPE']) {
 
             // fix "Incorrect decimal value: '' error in STRICT_MODE or STRICT_TRANS_TABLE
             // @see https://dev.mysql.com/doc/refman/5.7/en/sql-mode.html
@@ -43,10 +43,10 @@ function parse_columns($table_name, $postdata) {
                 if ($row['COLUMN_DEFAULT'] != 'CURRENT_TIMESTAMP' && $row['IS_NULLABLE'] == 'YES') {
                     $default = null;
                 } else {
-                    $default =  date('Y-m-d H:i:s');
+                    $default = date('Y-m-d H:i:s');
                 }
                 if ($postdata[$row['COLUMN_NAME']] == 'CURRENT_TIMESTAMP') {
-                    $_POST[$row['COLUMN_NAME']] =  date('Y-m-d H:i:s');
+                    $_POST[$row['COLUMN_NAME']] = date('Y-m-d H:i:s');
                 }
                 break;
         }
@@ -60,15 +60,15 @@ function parse_columns($table_name, $postdata) {
 
 
 // get extra attributes for  table keys on CREATE and UPDATE events
-function get_columns_attributes($table_name, $column) {
+function get_columns_attributes($table_name, $column)
+{
     global $link;
     $sql = "SELECT COLUMN_DEFAULT, COLUMN_COMMENT
             FROM INFORMATION_SCHEMA.COLUMNS
-            WHERE table_name = '".$table_name."'
-            AND column_name = '".$column."'";
-    $result = mysqli_query($link,$sql);
-    while($row = mysqli_fetch_assoc($result))
-    {
+            WHERE table_name = '" . $table_name . "'
+            AND column_name = '" . $column . "'";
+    $result = mysqli_query($link, $sql);
+    while ($row = mysqli_fetch_assoc($result)) {
         $debug = 0;
         if ($debug) {
             echo "<pre>";
@@ -79,40 +79,50 @@ function get_columns_attributes($table_name, $column) {
     }
 }
 
-function print_error_if_exists($error) {
-    if(isset($error)){
+function print_error_if_exists($error)
+{
+    if (isset($error)) {
         echo "<div class='alert alert-danger' role='alert'>$error</div>";
     }
 }
 
-function convert_date($date_str) {
-    if(isset($date_str)){
-        $date = date( 'd-m-Y', strtotime( $date_str ) );
+function convert_date($date_str)
+{
+    if (isset($date_str)) {
+        $date = date('d-m-Y', strtotime($date_str));
         return htmlspecialchars($date);
     }
 }
 
-function convert_datetime($date_str){
-    if(isset($date_str)){
-        $date = date( 'd-m-Y H:i:s', strtotime( $date_str ) );
+function convert_datetime($date_str)
+{
+    if (isset($date_str)) {
+        $date = date('d-m-Y H:i:s', strtotime($date_str));
         return htmlspecialchars($date);
     }
 }
 
-function convert_bool($var){
-    if(isset($var))
-    {
+function convert_bool($var)
+{
+    if (isset($var)) {
         return $var ? "True" : "False";
     }
 }
 
-function get_fk_url($value, $fk_table, $fk_column)
+function get_fk_url($value, $fk_table, $fk_column, $representation, bool $pk=false, bool $index=false)
 // Gets a URL to the foreign key parents read page
-{   
-    if(isset($value))
-    {
+{
+    if (isset($value)) {
         $value = htmlspecialchars($value);
-        return '<a href="' . $fk_table .'-read.php?' . $fk_column . '=' . $value .'">'. $value . '</a>';
+        if($pk)
+        {
+            return '<a href="' . $fk_table . '-read.php?' . $fk_column . '=' . $value . '">' . $representation . '</a>';
+        }
+        else
+        {
+            return '<a href="' . $fk_table . '-index.php?' . $fk_column . '=' . $value . '">' . $representation . '</a>';
+        }
+        
     }
 }
 ?>

--- a/core/helpers.php
+++ b/core/helpers.php
@@ -98,4 +98,14 @@ function convert_datetime($date_str){
         return htmlspecialchars($date);
     }
 }
+
+function get_fk_url($value, $fk_table, $fk_column)
+// Gets a URL to the foreign key parents read page
+{   
+    if(isset($value))
+    {
+        $value = htmlspecialchars($value);
+        return '<a href="' . $fk_table .'-read.php?' . $fk_column . '=' . $value .'">'. $value . '</a>';
+    }
+}
 ?>

--- a/core/helpers.php
+++ b/core/helpers.php
@@ -99,6 +99,13 @@ function convert_datetime($date_str){
     }
 }
 
+function convert_bool($var){
+    if(isset($var))
+    {
+        return $var ? "True" : "False";
+    }
+}
+
 function get_fk_url($value, $fk_table, $fk_column)
 // Gets a URL to the foreign key parents read page
 {   

--- a/core/helpers.php
+++ b/core/helpers.php
@@ -84,4 +84,18 @@ function print_error_if_exists($error) {
         echo "<div class='alert alert-danger' role='alert'>$error</div>";
     }
 }
+
+function convert_date($date_str) {
+    if(isset($date_str)){
+        $date = date( 'd-m-Y', strtotime( $date_str ) );
+        return htmlspecialchars($date);
+    }
+}
+
+function convert_datetime($date_str){
+    if(isset($date_str)){
+        $date = date( 'd-m-Y H:i:s', strtotime( $date_str ) );
+        return htmlspecialchars($date);
+    }
+}
 ?>

--- a/core/relations.php
+++ b/core/relations.php
@@ -50,6 +50,8 @@ if(isset($_POST['index'])) {
 	$txt .= "\$db_password = '$password'; \n";
 	$txt .= "\$no_of_records_per_page = $numrecordsperpage; \n";
 	$txt .= "\$appname = '$appname'; \n\n";
+    $txt .= "\$protocol=(\$_SERVER['HTTPS'] == 'on' ? 'https' : 'http');";
+    $txt .= "\$domain = \$protocol . '://' . \$_SERVER['SCRIPT_NAME'];";
 	$txt .= "\$link = mysqli_connect(\$db_server, \$db_user, \$db_password, \$db_name); \n";
 
     $txt .= '$query = "SHOW VARIABLES LIKE \'character_set_database\'";' ."\n";

--- a/core/relations.php
+++ b/core/relations.php
@@ -50,8 +50,8 @@ if(isset($_POST['index'])) {
 	$txt .= "\$db_password = '$password'; \n";
 	$txt .= "\$no_of_records_per_page = $numrecordsperpage; \n";
 	$txt .= "\$appname = '$appname'; \n\n";
-    $txt .= "\$protocol=(\$_SERVER['HTTPS'] == 'on' ? 'https' : 'http');";
-    $txt .= "\$domain = \$protocol . '://' . \$_SERVER['SCRIPT_NAME'];";
+    $txt .= "\$protocol=(\$_SERVER['HTTPS'] == 'on' ? 'https' : 'http');\n";
+    $txt .= "\$domain = \$protocol . '://' . \$_SERVER['SCRIPT_NAME']; //Replace domain with your domain name. (Locally typically something like localhost)\n\n";
 	$txt .= "\$link = mysqli_connect(\$db_server, \$db_user, \$db_password, \$db_name); \n";
 
     $txt .= '$query = "SHOW VARIABLES LIKE \'character_set_database\'";' ."\n";

--- a/core/templates.php
+++ b/core/templates.php
@@ -259,10 +259,15 @@ if(isset($_GET["{TABLE_ID}"]) && !empty($_GET["{TABLE_ID}"])){
             </div>
         </div>
     </section>
-<script src="https://code.jquery.com/jquery-3.5.1.min.js" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
-<script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
-<script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/js/bootstrap.min.js" integrity="sha384-OgVRvuATP1z7JjHLkuOU7Xw704+h835Lr+6QL9UvYjZE3Ipu6Tp75j7Bh/kR0JKI" crossorigin="anonymous"></script>
-</body>
+    <script src="https://code.jquery.com/jquery-3.5.1.min.js" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/js/bootstrap.min.js" integrity="sha384-OgVRvuATP1z7JjHLkuOU7Xw704+h835Lr+6QL9UvYjZE3Ipu6Tp75j7Bh/kR0JKI" crossorigin="anonymous"></script>
+        <script type="text/javascript">
+            $(document).ready(function(){
+                $('[data-toggle="tooltip"]').tooltip();
+            });
+        </script>
+    </body>
 </html>
 EOT;
 
@@ -347,6 +352,11 @@ if(isset($_POST["{TABLE_ID}"]) && !empty($_POST["{TABLE_ID}"])){
 <script src="https://code.jquery.com/jquery-3.5.1.min.js" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
 <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
 <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/js/bootstrap.min.js" integrity="sha384-OgVRvuATP1z7JjHLkuOU7Xw704+h835Lr+6QL9UvYjZE3Ipu6Tp75j7Bh/kR0JKI" crossorigin="anonymous"></script>
+    <script type="text/javascript">
+        $(document).ready(function(){
+            $('[data-toggle="tooltip"]').tooltip();
+        });
+    </script>
 </body>
 </html>
 
@@ -423,6 +433,11 @@ if($_SERVER["REQUEST_METHOD"] == "POST"){
 <script src="https://code.jquery.com/jquery-3.5.1.min.js" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
 <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
 <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/js/bootstrap.min.js" integrity="sha384-OgVRvuATP1z7JjHLkuOU7Xw704+h835Lr+6QL9UvYjZE3Ipu6Tp75j7Bh/kR0JKI" crossorigin="anonymous"></script>
+    <script type="text/javascript">
+        $(document).ready(function(){
+            $('[data-toggle="tooltip"]').tooltip();
+        });
+    </script>
 </body>
 </html>
 EOT;
@@ -553,6 +568,15 @@ if(isset($_POST["{COLUMN_ID}"]) && !empty($_POST["{COLUMN_ID}"])){
             </div>
         </div>
     </section>
+</body>
+<script src="https://code.jquery.com/jquery-3.5.1.min.js" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
+<script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/js/bootstrap.min.js" integrity="sha384-OgVRvuATP1z7JjHLkuOU7Xw704+h835Lr+6QL9UvYjZE3Ipu6Tp75j7Bh/kR0JKI" crossorigin="anonymous"></script>
+    <script type="text/javascript">
+        $(document).ready(function(){
+            $('[data-toggle="tooltip"]').tooltip();
+        });
+    </script>
 </body>
 </html>
 

--- a/core/templates.php
+++ b/core/templates.php
@@ -279,11 +279,12 @@ EOT;
 
 $deletefile = <<<'EOT'
 <?php
+// Include config file
+require_once "config.php";
+require_once "helpers.php";
+
 // Process delete operation after confirmation
 if(isset($_POST["{TABLE_ID}"]) && !empty($_POST["{TABLE_ID}"])){
-    // Include config file
-    require_once "config.php";
-    require_once "helpers.php";
 
     // Prepare a delete statement
     $sql = "DELETE FROM {TABLE_NAME} WHERE {TABLE_ID} = ?";
@@ -299,13 +300,16 @@ if(isset($_POST["{TABLE_ID}"]) && !empty($_POST["{TABLE_ID}"])){
 		else $__vartype = "b"; // blob
         mysqli_stmt_bind_param($stmt, $__vartype, $param_id);
 
-        // Attempt to execute the prepared statement
-        if(mysqli_stmt_execute($stmt)){
+        try {
+            mysqli_stmt_execute($stmt);
+        } catch (Exception $e) {
+            error_log($e->getMessage());
+            $error = $e->getMessage();
+        }
+    
+        if (!isset($error)){
             // Records deleted successfully. Redirect to landing page
             header("location: {TABLE_NAME}-index.php");
-            exit();
-        } else{
-            echo "Oops! Something went wrong. Please try again later.<br>".$stmt->error;
         }
     }
 
@@ -341,7 +345,8 @@ if(isset($_POST["{TABLE_ID}"]) && !empty($_POST["{TABLE_ID}"])){
                     <div class="page-header">
                         <h1>Delete Record</h1>
                     </div>
-                    <form action="<?php echo htmlspecialchars($_SERVER['PHP_SELF']); ?>" method="post">
+                    <form action="<?php echo htmlspecialchars($_SERVER['PHP_SELF']) . "?{TABLE_ID}=" . $_GET["{TABLE_ID}"]; ?>" method="post">
+                    <?php print_error_if_exists($error); ?>
                         <div class="alert alert-danger fade-in">
                             <input type="hidden" name="{TABLE_ID}" value="<?php echo trim($_GET["{TABLE_ID}"]); ?>"/>
                             <p>Are you sure you want to delete this record?</p><br>
@@ -351,6 +356,11 @@ if(isset($_POST["{TABLE_ID}"]) && !empty($_POST["{TABLE_ID}"])){
                             </p>
                         </div>
                     </form>
+                    <p>
+                        <a href="{TABLE_NAME}-read.php?{TABLE_ID}=<?php echo $_GET["{TABLE_ID}"];?>" class="btn btn-info">View</a>
+                        <a href="{TABLE_NAME}-update.php?{TABLE_ID}=<?php echo $_GET["{TABLE_ID}"];?>" class="btn btn-secondary">Edit</a>
+                        <a href="{TABLE_NAME}-index.php" class="btn btn-primary">Back</a>
+                    </p>
                 </div>
             </div>
         </div>

--- a/core/templates.php
+++ b/core/templates.php
@@ -111,7 +111,8 @@ $indexfile = <<<'EOT'
                             GROUP BY `{TABLE_NAME}`.`{COLUMN_ID}`
                             ORDER BY `$order` $sort
                             LIMIT $offset, $no_of_records_per_page;";
-                    $count_pages = "SELECT COUNT(*) AS count FROM `{TABLE_NAME}` $where_statement";
+                    $count_pages = "SELECT COUNT(*) AS count FROM `{TABLE_NAME}` {JOIN_CLAUSES}
+                            $where_statement";
 
                     if($result = mysqli_query($link, $sql)){
                         if(mysqli_num_rows($result) > 0){

--- a/core/templates.php
+++ b/core/templates.php
@@ -267,7 +267,7 @@ if(isset($_GET["{TABLE_ID}"]) && !empty($_GET["{TABLE_ID}"])){
                     </p> 
                     <?php
                     {FOREIGN_KEY_REFS}
-                    
+
                     // Close connection
                     mysqli_close($link);
                     ?>
@@ -395,10 +395,6 @@ $createfile = <<<'EOT'
 require_once "config.php";
 require_once "helpers.php";
 
-// Define variables and initialize with empty values
-{CREATE_RECORDS}
-{CREATE_ERR_RECORDS}
-
 // Processing form data when form is submitted
 if($_SERVER["REQUEST_METHOD"] == "POST"){
     {CREATE_POST_VARIABLES}
@@ -468,10 +464,6 @@ $updatefile = <<<'EOT'
 // Include config file
 require_once "config.php";
 require_once "helpers.php";
-
-// Define variables and initialize with empty values
-{CREATE_RECORDS}
-{CREATE_ERR_RECORDS}
 
 // Processing form data when form is submitted
 if(isset($_POST["{COLUMN_ID}"]) && !empty($_POST["{COLUMN_ID}"])){

--- a/core/templates.php
+++ b/core/templates.php
@@ -64,7 +64,7 @@ $indexfile = <<<'EOT'
                     //$no_of_records_per_page is set on the index page. Default is 10.
                     $offset = ($pageno-1) * $no_of_records_per_page;
 
-                    $total_pages_sql = "SELECT COUNT(*) FROM {TABLE_NAME}";
+                    $total_pages_sql = "SELECT COUNT(*) FROM `{TABLE_NAME}`";
                     $result = mysqli_query($link,$total_pages_sql);
                     $total_rows = mysqli_fetch_array($result)[0];
                     $total_pages = ceil($total_rows / $no_of_records_per_page);
@@ -95,26 +95,25 @@ $indexfile = <<<'EOT'
                     $get_param = "";                    
                     $where_statement = " WHERE 1=1 ";
                     foreach ( $where_columns as $key => $val ) {
-                        $where_statement .= " AND $key = '" . mysqli_real_escape_string($link, $val) . "' ";
+                        $where_statement .= " AND `$key` = '" . mysqli_real_escape_string($link, $val) . "' ";
                         $get_param .= "&$key=$val";
                     }
 
                     // Attempt select query execution
-                    $sql = "{INDEX_QUERY} $where_statement ORDER BY $order $sort LIMIT $offset, $no_of_records_per_page";
-                    $count_pages = "SELECT COUNT(*) AS count FROM {TABLE_NAME} $where_statement";
+                    $sql = "{INDEX_QUERY} $where_statement ORDER BY `$order` $sort LIMIT $offset, $no_of_records_per_page";
+                    $count_pages = "SELECT COUNT(*) AS count FROM `{TABLE_NAME}` $where_statement";
 
 
                     if(!empty($_GET['search'])) {
                         $search = mysqli_real_escape_string($link, $_GET['search']);
-                        $sql = "SELECT * FROM {TABLE_NAME}
+                        $sql = "SELECT * FROM `{TABLE_NAME}`
                             $where_statement AND CONCAT_WS ({INDEX_CONCAT_SEARCH_FIELDS})
                             LIKE '%$search%'
-                            ORDER BY $order $sort
+                            ORDER BY `$order` $sort
                             LIMIT $offset, $no_of_records_per_page";
-                        $count_pages = "SELECT COUNT(*) AS count FROM {TABLE_NAME}
+                        $count_pages = "SELECT COUNT(*) AS count FROM `{TABLE_NAME}`
                             $where_statement AND CONCAT_WS ({INDEX_CONCAT_SEARCH_FIELDS})
-                            LIKE '%$search%'
-                            ORDER BY $order $sort";
+                            LIKE '%$search%'";
                     }
                     else {
                         $search = "";
@@ -202,7 +201,7 @@ if(isset($_GET["{TABLE_ID}"]) && !empty($_GET["{TABLE_ID}"])){
     require_once "helpers.php";
 
     // Prepare a select statement
-    $sql = "SELECT * FROM {TABLE_NAME} WHERE {TABLE_ID} = ?";
+    $sql = "SELECT * FROM `{TABLE_NAME}` WHERE `{TABLE_ID}` = ?";
 
     if($stmt = mysqli_prepare($link, $sql)){
         // Set parameters
@@ -300,7 +299,7 @@ require_once "helpers.php";
 if(isset($_POST["{TABLE_ID}"]) && !empty($_POST["{TABLE_ID}"])){
 
     // Prepare a delete statement
-    $sql = "DELETE FROM {TABLE_NAME} WHERE {TABLE_ID} = ?";
+    $sql = "DELETE FROM `{TABLE_NAME}` WHERE `{TABLE_ID}` = ?";
 
     if($stmt = mysqli_prepare($link, $sql)){
         // Set parameters
@@ -401,7 +400,7 @@ require_once "helpers.php";
 if($_SERVER["REQUEST_METHOD"] == "POST"){
     {CREATE_POST_VARIABLES}
 
-    $stmt = $link->prepare("INSERT INTO {TABLE_NAME} ({CREATE_COLUMN_NAMES}) VALUES ({CREATE_QUESTIONMARK_PARAMS})");
+    $stmt = $link->prepare("INSERT INTO `{TABLE_NAME}` ({CREATE_COLUMN_NAMES}) VALUES ({CREATE_QUESTIONMARK_PARAMS})");
 
     try {
         $stmt->execute([ {CREATE_SQL_PARAMS} ]);
@@ -476,7 +475,7 @@ if(isset($_POST["{COLUMN_ID}"]) && !empty($_POST["{COLUMN_ID}"])){
 
     // Prepare an update statement
 
-    $stmt = $link->prepare("UPDATE {TABLE_NAME} SET {UPDATE_SQL_PARAMS} WHERE {UPDATE_SQL_ID}");
+    $stmt = $link->prepare("UPDATE `{TABLE_NAME}` SET {UPDATE_SQL_PARAMS} WHERE {UPDATE_SQL_ID}");
 
     try {
         $stmt->execute([ {UPDATE_SQL_COLUMNS}  ]);
@@ -496,7 +495,7 @@ if(isset($_GET["{COLUMN_ID}"]) && !empty($_GET["{COLUMN_ID}"])){
     ${COLUMN_ID} =  trim($_GET["{COLUMN_ID}"]);
 
     // Prepare a select statement
-    $sql = "SELECT * FROM {TABLE_NAME} WHERE {COLUMN_ID} = ?";
+    $sql = "SELECT * FROM `{TABLE_NAME}` WHERE `{COLUMN_ID}` = ?";
     if($stmt = mysqli_prepare($link, $sql)){
         // Set parameters
         $param_id = ${COLUMN_ID};

--- a/core/templates.php
+++ b/core/templates.php
@@ -89,7 +89,7 @@ $indexfile = <<<'EOT'
 
                     // Attempt select query execution
                     $sql = "{INDEX_QUERY} ORDER BY $order $sort LIMIT $offset, $no_of_records_per_page";
-                    $count_pages = "{INDEX_QUERY}";
+                    $count_pages = "SELECT COUNT(*) AS count FROM {TABLE_NAME}";
 
 
                     if(!empty($_GET['search'])) {
@@ -99,7 +99,7 @@ $indexfile = <<<'EOT'
                             LIKE '%$search%'
                             ORDER BY $order $sort
                             LIMIT $offset, $no_of_records_per_page";
-                        $count_pages = "SELECT * FROM {TABLE_NAME}
+                        $count_pages = "SELECT COUNT(*) AS count FROM {TABLE_NAME}
                             WHERE CONCAT_WS ({INDEX_CONCAT_SEARCH_FIELDS})
                             LIKE '%$search%'
                             ORDER BY $order $sort";
@@ -110,10 +110,8 @@ $indexfile = <<<'EOT'
 
                     if($result = mysqli_query($link, $sql)){
                         if(mysqli_num_rows($result) > 0){
-                            if ($result_count = mysqli_query($link, $count_pages)) {
-                               $total_pages = ceil(mysqli_num_rows($result_count) / $no_of_records_per_page);
-                           }
-                            $number_of_results = mysqli_num_rows($result_count);
+                            $number_of_results = mysqli_fetch_assoc(mysqli_query($link, $count_pages))['count'];
+                            $total_pages = ceil($number_of_results / $no_of_records_per_page);
                             echo " " . $number_of_results . " results - Page " . $pageno . " of " . $total_pages;
 
                             echo "<table class='table table-bordered table-striped'>";

--- a/core/templates.php
+++ b/core/templates.php
@@ -73,11 +73,14 @@ $indexfile = <<<'EOT'
                     $orderBy = array('{COLUMNS}');
                     $order = '{COLUMN_ID}';
                     if (isset($_GET['order']) && in_array($_GET['order'], $orderBy)) {
-                            $order = $_GET['order'];
-                        }
+                        $order = $_GET['order'];
+                    } else {
+                    // Order by primary key on default
+                        $order = $orderBy[0];
+                    }
 
                     //Column sort order
-                    $sortBy = array('asc', 'desc'); $sort = 'desc';
+                    $sortBy = array('asc', 'desc'); $sort = 'asc';
                     if (isset($_GET['sort']) && in_array($_GET['sort'], $sortBy)) {
                           if($_GET['sort']=='asc') {
                             $sort='desc';

--- a/core/templates.php
+++ b/core/templates.php
@@ -30,7 +30,7 @@ $indexfile = <<<'EOT'
                         <h2 class="float-left">{TABLE_DISPLAY} Details</h2>
                         <a href="{TABLE_NAME}-create.php" class="btn btn-success float-right">Add New Record</a>
                         <a href="{TABLE_NAME}-index.php" class="btn btn-info float-right mr-2">Reset View</a>
-                        <a href="index.php" class="btn btn-secondary float-right mr-2">Back</a>
+                        <a href="javascript:history.back()" class="btn btn-secondary float-right mr-2">Back</a>
                     </div>
 
                     <div class="form-row">
@@ -91,10 +91,12 @@ $indexfile = <<<'EOT'
                     }
 
                     //Generate WHERE statements for param
-                    $where_columns = array_intersect_key($_GET, array_flip($columns));                    
+                    $where_columns = array_intersect_key($_GET, array_flip($columns));
+                    $get_param = "";                    
                     $where_statement = " WHERE 1=1 ";
                     foreach ( $where_columns as $key => $val ) {
                         $where_statement .= " AND $key = '" . mysqli_real_escape_string($link, $val) . "' ";
+                        $get_param .= "&$key=$val";
                     }
 
                     // Attempt select query execution
@@ -263,7 +265,7 @@ if(isset($_GET["{TABLE_ID}"]) && !empty($_GET["{TABLE_ID}"])){
                     <p>
                         <a href="{TABLE_NAME}-update.php?{TABLE_ID}=<?php echo $_GET["{TABLE_ID}"];?>" class="btn btn-secondary">Edit</a>
                         <a href="{TABLE_NAME}-delete.php?{TABLE_ID}=<?php echo $_GET["{TABLE_ID}"];?>" class="btn btn-warning">Delete</a>
-                        <a href="{TABLE_NAME}-index.php" class="btn btn-primary">Back</a>
+                        <a href="javascript:history.back()" class="btn btn-primary">Back</a>
                     </p> 
                     <?php
                     {FOREIGN_KEY_REFS}
@@ -363,14 +365,14 @@ if(isset($_POST["{TABLE_ID}"]) && !empty($_POST["{TABLE_ID}"])){
                             <p>Are you sure you want to delete this record?</p><br>
                             <p>
                                 <input type="submit" value="Yes" class="btn btn-danger">
-                                <a href="{TABLE_NAME}-index.php" class="btn btn-secondary">No</a>
+                                <a href="javascript:history.back()" class="btn btn-secondary">No</a>
                             </p>
                         </div>
                     </form>
                     <p>
                         <a href="{TABLE_NAME}-read.php?{TABLE_ID}=<?php echo $_GET["{TABLE_ID}"];?>" class="btn btn-info">View</a>
                         <a href="{TABLE_NAME}-update.php?{TABLE_ID}=<?php echo $_GET["{TABLE_ID}"];?>" class="btn btn-secondary">Edit</a>
-                        <a href="{TABLE_NAME}-index.php" class="btn btn-primary">Back</a>
+                        <a href="javascript:history.back()" class="btn btn-primary">Back</a>
                     </p>
                 </div>
             </div>
@@ -566,12 +568,12 @@ if(isset($_GET["{COLUMN_ID}"]) && !empty($_GET["{COLUMN_ID}"])){
                         <input type="hidden" name="{COLUMN_ID}" value="<?php echo ${COLUMN_ID}; ?>"/>
                         <p>
                             <input type="submit" class="btn btn-primary" value="Submit">
-                            <a href="{TABLE_NAME}-index.php" class="btn btn-secondary">Cancel</a>
+                            <a href="javascript:history.back()" class="btn btn-secondary">Cancel</a>
                         </p>
                         <p>
                             <a href="{TABLE_NAME}-read.php?{COLUMN_ID}=<?php echo $_GET["{COLUMN_ID}"];?>" class="btn btn-info">View</a>
                             <a href="{TABLE_NAME}-delete.php?{COLUMN_ID}=<?php echo $_GET["{COLUMN_ID}"];?>" class="btn btn-warning">Delete</a>
-                            <a href="{TABLE_NAME}-index.php" class="btn btn-primary">Back</a>
+                            <a href="javascript:history.back()" class="btn btn-primary">Back</a>
                         </p>
                         <p> * field can not be left empty </p>
                     </form>

--- a/core/templates.php
+++ b/core/templates.php
@@ -141,7 +141,7 @@ $indexfile = <<<'EOT'
                                 echo "</tbody>";
                             echo "</table>";
 ?>
-                                <ul class="pagination fixed-bottom" align-right>
+                                <ul class="pagination" align-right>
                                 <?php
                                     $new_url = preg_replace('/&?pageno=[^&]*/', '', $currenturl);
                                  ?>

--- a/core/templates.php
+++ b/core/templates.php
@@ -235,8 +235,6 @@ if(isset($_GET["{TABLE_ID}"]) && !empty($_GET["{TABLE_ID}"])){
     // Close statement
     mysqli_stmt_close($stmt);
 
-    // Close connection
-    mysqli_close($link);
 } else{
     // URL doesn't contain id parameter. Redirect to error page
     header("location: error.php");
@@ -267,7 +265,12 @@ if(isset($_GET["{TABLE_ID}"]) && !empty($_GET["{TABLE_ID}"])){
                         <a href="{TABLE_NAME}-delete.php?{TABLE_ID}=<?php echo $_GET["{TABLE_ID}"];?>" class="btn btn-warning">Delete</a>
                         <a href="{TABLE_NAME}-index.php" class="btn btn-primary">Back</a>
                     </p> 
-                    {FOREIGN_KEY_REFS}                   
+                    <?php
+                    {FOREIGN_KEY_REFS}
+                    
+                    // Close connection
+                    mysqli_close($link);
+                    ?>
                 </div>
             </div>
         </div>

--- a/core/templates.php
+++ b/core/templates.php
@@ -6,8 +6,8 @@ $indexfile = <<<'EOT'
 <head>
     <meta charset="UTF-8">
     <title>{APP_NAME}</title>
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css" integrity="sha384-9aIt2nRpC12Uk9gS9baDl411NQApFmC26EwAOH8WgZl5MYYxFfc+NcPb1dKGj7Sk" crossorigin="anonymous">
-    <script src="https://kit.fontawesome.com/6b773fe9e4.js" crossorigin="anonymous"></script>
+    <link rel="stylesheet" href="css/style.css" type="text/css"/>
+    <link rel="stylesheet" href="css/bootstrap.min.css" type="text/css"/><script src="https://kit.fontawesome.com/6b773fe9e4.js" crossorigin="anonymous"></script>
     <style type="text/css">
         .page-header h2{
             margin-top: 0;
@@ -240,7 +240,8 @@ if(isset($_GET["{TABLE_ID}"]) && !empty($_GET["{TABLE_ID}"])){
 <head>
     <meta charset="UTF-8">
     <title>View Record</title>
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css" integrity="sha384-9aIt2nRpC12Uk9gS9baDl411NQApFmC26EwAOH8WgZl5MYYxFfc+NcPb1dKGj7Sk" crossorigin="anonymous">
+    <link rel="stylesheet" href="css/style.css" type="text/css"/>
+    <link rel="stylesheet" href="css/bootstrap.min.css" type="text/css"/>
 </head>
 <?php require_once('navbar.php'); ?>
 <body>
@@ -324,7 +325,8 @@ if(isset($_POST["{TABLE_ID}"]) && !empty($_POST["{TABLE_ID}"])){
 <head>
     <meta charset="UTF-8">
     <title>View Record</title>
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css" integrity="sha384-9aIt2nRpC12Uk9gS9baDl411NQApFmC26EwAOH8WgZl5MYYxFfc+NcPb1dKGj7Sk" crossorigin="anonymous">
+    <link rel="stylesheet" href="css/style.css" type="text/css"/>
+    <link rel="stylesheet" href="css/bootstrap.min.css" type="text/css"/>
 </head>
 <?php require_once('navbar.php'); ?>
 <body>
@@ -407,7 +409,8 @@ if($_SERVER["REQUEST_METHOD"] == "POST"){
 <head>
     <meta charset="UTF-8">
     <title>Create Record</title>
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css" integrity="sha384-9aIt2nRpC12Uk9gS9baDl411NQApFmC26EwAOH8WgZl5MYYxFfc+NcPb1dKGj7Sk" crossorigin="anonymous">
+    <link rel="stylesheet" href="css/style.css" type="text/css"/>
+    <link rel="stylesheet" href="css/bootstrap.min.css" type="text/css"/>
 </head>
 <?php require_once('navbar.php'); ?>
 <body>
@@ -543,8 +546,9 @@ if(isset($_POST["{COLUMN_ID}"]) && !empty($_POST["{COLUMN_ID}"])){
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Update Record</title>
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css" integrity="sha384-9aIt2nRpC12Uk9gS9baDl411NQApFmC26EwAOH8WgZl5MYYxFfc+NcPb1dKGj7Sk" crossorigin="anonymous">
+    <title>Update Record</title>    
+    <link rel="stylesheet" href="css/style.css" type="text/css"/>
+    <link rel="stylesheet" href="css/bootstrap.min.css" type="text/css"/>
 </head>
 <?php require_once('navbar.php'); ?>
 <body>
@@ -588,7 +592,8 @@ $errorfile = <<<'EOT'
 <head>
     <meta charset="UTF-8">
     <title>Error</title>
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css" integrity="sha384-9aIt2nRpC12Uk9gS9baDl411NQApFmC26EwAOH8WgZl5MYYxFfc+NcPb1dKGj7Sk" crossorigin="anonymous">
+    <link rel="stylesheet" href="css/style.css" type="text/css"/>
+    <link rel="stylesheet" href="css/bootstrap.min.css" type="text/css"/>
 </head>
 <body>
     <section class="pt-5">
@@ -617,7 +622,8 @@ $startfile = <<<'EOT'
 <head>                                                                                                                                                                                                             
     <meta charset="UTF-8">                                                                                                                                                                                         
     <title>{APP_NAME}</title>                                                                                                                                                                               
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css" integrity="sha384-9aIt2nRpC12Uk9gS9baDl411NQApFmC26EwAOH8WgZl5MYYxFfc+NcPb1dKGj7Sk" crossorigin="anonymous">
+    <link rel="stylesheet" href="css/style.css" type="text/css"/>
+    <link rel="stylesheet" href="css/bootstrap.min.css" type="text/css"/>
 
         <script src="https://code.jquery.com/jquery-3.5.1.min.js" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
         <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>

--- a/core/templates.php
+++ b/core/templates.php
@@ -382,7 +382,6 @@ require_once "helpers.php";
 if($_SERVER["REQUEST_METHOD"] == "POST"){
     {CREATE_POST_VARIABLES}
 
-    $vars = parse_columns('{TABLE_NAME}', $_POST);
     $stmt = $link->prepare("INSERT INTO {TABLE_NAME} ({CREATE_COLUMN_NAMES}) VALUES ({CREATE_QUESTIONMARK_PARAMS})");
 
     try {
@@ -461,7 +460,6 @@ if(isset($_POST["{COLUMN_ID}"]) && !empty($_POST["{COLUMN_ID}"])){
 
     // Prepare an update statement
 
-    $vars = parse_columns('{TABLE_NAME}', $_POST);
     $stmt = $link->prepare("UPDATE {TABLE_NAME} SET {UPDATE_SQL_PARAMS} WHERE {UPDATE_SQL_ID}");
 
     try {

--- a/core/templates.php
+++ b/core/templates.php
@@ -121,7 +121,7 @@ $indexfile = <<<'EOT'
                             echo " " . $number_of_results . " results - Page " . $pageno . " of " . $total_pages;
 
                             echo "<table class='table table-bordered table-striped'>";
-                                echo "<thead>";
+                                echo "<thead class='thead-light'>";
                                     echo "<tr>";
                                         {INDEX_TABLE_HEADERS}
                                         echo "<th>Action</th>";
@@ -141,7 +141,7 @@ $indexfile = <<<'EOT'
                                 echo "</tbody>";
                             echo "</table>";
 ?>
-                                <ul class="pagination" align-right>
+                                <ul class="pagination fixed-bottom" align-right>
                                 <?php
                                     $new_url = preg_replace('/&?pageno=[^&]*/', '', $currenturl);
                                  ?>

--- a/core/templates.php
+++ b/core/templates.php
@@ -255,8 +255,11 @@ if(isset($_GET["{TABLE_ID}"]) && !empty($_GET["{TABLE_ID}"])){
                     </div>
 
                      {RECORDS_READ_FORM}
-
-                    <p><a href="{TABLE_NAME}-index.php" class="btn btn-primary">Back</a></p>
+                    <p>
+                        <a href="{TABLE_NAME}-update.php?{TABLE_ID}=<?php echo $_GET["{TABLE_ID}"];?>" class="btn btn-secondary">Edit</a>
+                        <a href="{TABLE_NAME}-delete.php?{TABLE_ID}=<?php echo $_GET["{TABLE_ID}"];?>" class="btn btn-warning">Delete</a>
+                        <a href="{TABLE_NAME}-index.php" class="btn btn-primary">Back</a>
+                    </p>                    
                 </div>
             </div>
         </div>
@@ -566,8 +569,15 @@ if(isset($_POST["{COLUMN_ID}"]) && !empty($_POST["{COLUMN_ID}"])){
                         {CREATE_HTML}
 
                         <input type="hidden" name="{COLUMN_ID}" value="<?php echo ${COLUMN_ID}; ?>"/>
-                        <input type="submit" class="btn btn-primary" value="Submit">
-                        <a href="{TABLE_NAME}-index.php" class="btn btn-secondary">Cancel</a>
+                        <p>
+                            <input type="submit" class="btn btn-primary" value="Submit">
+                            <a href="{TABLE_NAME}-index.php" class="btn btn-secondary">Cancel</a>
+                        </p>
+                        <p>
+                            <a href="{TABLE_NAME}-read.php?{COLUMN_ID}=<?php echo $_GET["{COLUMN_ID}"];?>" class="btn btn-info">View</a>
+                            <a href="{TABLE_NAME}-delete.php?{COLUMN_ID}=<?php echo $_GET["{COLUMN_ID}"];?>" class="btn btn-warning">Delete</a>
+                            <a href="{TABLE_NAME}-index.php" class="btn btn-primary">Back</a>
+                        </p>
                     </form>
                 </div>
             </div>

--- a/core/templates.php
+++ b/core/templates.php
@@ -6,8 +6,8 @@ $indexfile = <<<'EOT'
 <head>
     <meta charset="UTF-8">
     <title>{APP_NAME}</title>
-    <link rel="stylesheet" href="css/style.css" type="text/css"/>
-    <link rel="stylesheet" href="css/bootstrap.min.css" type="text/css"/><script src="https://kit.fontawesome.com/6b773fe9e4.js" crossorigin="anonymous"></script>
+    {CSS_REFS}
+    <script src="https://kit.fontawesome.com/6b773fe9e4.js" crossorigin="anonymous"></script>
     <style type="text/css">
         .page-header h2{
             margin-top: 0;
@@ -172,9 +172,7 @@ $indexfile = <<<'EOT'
             </div>
         </div>
     </section>
-<script src="https://code.jquery.com/jquery-3.5.1.min.js" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
-<script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
-<script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/js/bootstrap.min.js" integrity="sha384-OgVRvuATP1z7JjHLkuOU7Xw704+h835Lr+6QL9UvYjZE3Ipu6Tp75j7Bh/kR0JKI" crossorigin="anonymous"></script>
+{JS_REFS}
     <script type="text/javascript">
         $(document).ready(function(){
             $('[data-toggle="tooltip"]').tooltip();
@@ -244,8 +242,7 @@ if(isset($_GET["{TABLE_ID}"]) && !empty($_GET["{TABLE_ID}"])){
 <head>
     <meta charset="UTF-8">
     <title>View Record</title>
-    <link rel="stylesheet" href="css/style.css" type="text/css"/>
-    <link rel="stylesheet" href="css/bootstrap.min.css" type="text/css"/>
+    {CSS_REFS}
 </head>
 <?php require_once('navbar.php'); ?>
 <body>
@@ -273,9 +270,7 @@ if(isset($_GET["{TABLE_ID}"]) && !empty($_GET["{TABLE_ID}"])){
             </div>
         </div>
     </section>
-    <script src="https://code.jquery.com/jquery-3.5.1.min.js" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
-    <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
-    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/js/bootstrap.min.js" integrity="sha384-OgVRvuATP1z7JjHLkuOU7Xw704+h835Lr+6QL9UvYjZE3Ipu6Tp75j7Bh/kR0JKI" crossorigin="anonymous"></script>
+    {JS_REFS}
         <script type="text/javascript">
             $(document).ready(function(){
                 $('[data-toggle="tooltip"]').tooltip();
@@ -342,8 +337,7 @@ if(isset($_POST["{TABLE_ID}"]) && !empty($_POST["{TABLE_ID}"])){
 <head>
     <meta charset="UTF-8">
     <title>View Record</title>
-    <link rel="stylesheet" href="css/style.css" type="text/css"/>
-    <link rel="stylesheet" href="css/bootstrap.min.css" type="text/css"/>
+    {CSS_REFS}
 </head>
 <?php require_once('navbar.php'); ?>
 <body>
@@ -374,9 +368,7 @@ if(isset($_POST["{TABLE_ID}"]) && !empty($_POST["{TABLE_ID}"])){
             </div>
         </div>
     </section>
-<script src="https://code.jquery.com/jquery-3.5.1.min.js" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
-<script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
-<script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/js/bootstrap.min.js" integrity="sha384-OgVRvuATP1z7JjHLkuOU7Xw704+h835Lr+6QL9UvYjZE3Ipu6Tp75j7Bh/kR0JKI" crossorigin="anonymous"></script>
+{JS_REFS}
     <script type="text/javascript">
         $(document).ready(function(){
             $('[data-toggle="tooltip"]').tooltip();
@@ -418,8 +410,7 @@ if($_SERVER["REQUEST_METHOD"] == "POST"){
 <head>
     <meta charset="UTF-8">
     <title>Create Record</title>
-    <link rel="stylesheet" href="css/style.css" type="text/css"/>
-    <link rel="stylesheet" href="css/bootstrap.min.css" type="text/css"/>
+    {CSS_REFS}
 </head>
 <?php require_once('navbar.php'); ?>
 <body>
@@ -444,9 +435,7 @@ if($_SERVER["REQUEST_METHOD"] == "POST"){
             </div>
         </div>
     </section>
-<script src="https://code.jquery.com/jquery-3.5.1.min.js" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
-<script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
-<script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/js/bootstrap.min.js" integrity="sha384-OgVRvuATP1z7JjHLkuOU7Xw704+h835Lr+6QL9UvYjZE3Ipu6Tp75j7Bh/kR0JKI" crossorigin="anonymous"></script>
+{JS_REFS}
     <script type="text/javascript">
         $(document).ready(function(){
             $('[data-toggle="tooltip"]').tooltip();
@@ -542,9 +531,8 @@ if(isset($_GET["{COLUMN_ID}"]) && !empty($_GET["{COLUMN_ID}"])){
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Update Record</title>    
-    <link rel="stylesheet" href="css/style.css" type="text/css"/>
-    <link rel="stylesheet" href="css/bootstrap.min.css" type="text/css"/>
+    <title>Update Record</title>
+    {CSS_REFS}
 </head>
 <?php require_once('navbar.php'); ?>
 <body>
@@ -578,9 +566,7 @@ if(isset($_GET["{COLUMN_ID}"]) && !empty($_GET["{COLUMN_ID}"])){
         </div>
     </section>
 </body>
-<script src="https://code.jquery.com/jquery-3.5.1.min.js" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
-<script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
-<script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/js/bootstrap.min.js" integrity="sha384-OgVRvuATP1z7JjHLkuOU7Xw704+h835Lr+6QL9UvYjZE3Ipu6Tp75j7Bh/kR0JKI" crossorigin="anonymous"></script>
+{JS_REFS}
     <script type="text/javascript">
         $(document).ready(function(){
             $('[data-toggle="tooltip"]').tooltip();
@@ -597,8 +583,7 @@ $errorfile = <<<'EOT'
 <head>
     <meta charset="UTF-8">
     <title>Error</title>
-    <link rel="stylesheet" href="css/style.css" type="text/css"/>
-    <link rel="stylesheet" href="css/bootstrap.min.css" type="text/css"/>
+    {CSS_REFS}
 </head>
 <body>
     <section class="pt-5">
@@ -615,9 +600,7 @@ $errorfile = <<<'EOT'
             </div>
         </div>
     </section>
-<script src="https://code.jquery.com/jquery-3.5.1.min.js" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
-<script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
-<script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/js/bootstrap.min.js" integrity="sha384-OgVRvuATP1z7JjHLkuOU7Xw704+h835Lr+6QL9UvYjZE3Ipu6Tp75j7Bh/kR0JKI" crossorigin="anonymous"></script>
+    {JS_REFS}
 </body>
 </html>
 EOT;
@@ -626,13 +609,9 @@ $startfile = <<<'EOT'
 <html lang="en">                                                                                                                                                                                                   
 <head>                                                                                                                                                                                                             
     <meta charset="UTF-8">                                                                                                                                                                                         
-    <title>{APP_NAME}</title>                                                                                                                                                                               
-    <link rel="stylesheet" href="css/style.css" type="text/css"/>
-    <link rel="stylesheet" href="css/bootstrap.min.css" type="text/css"/>
-
-        <script src="https://code.jquery.com/jquery-3.5.1.min.js" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
-        <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
-        <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/js/bootstrap.min.js" integrity="sha384-OgVRvuATP1z7JjHLkuOU7Xw704+h835Lr+6QL9UvYjZE3Ipu6Tp75j7Bh/kR0JKI" crossorigin="anonymous"></script>
+    <title>{APP_NAME}</title>
+    {CSS_REFS}
+    {JS_REFS}
 
     <style type="text/css">                                                                                                                                                                                        
         .page-header h2{                                                                                                                                                                                           

--- a/core/templates.php
+++ b/core/templates.php
@@ -424,6 +424,7 @@ if($_SERVER["REQUEST_METHOD"] == "POST"){
                         <input type="submit" class="btn btn-primary" value="Submit">
                         <a href="{TABLE_NAME}-index.php" class="btn btn-secondary">Cancel</a>
                     </form>
+                    <p> * field can not be left empty </p>
                 </div>
             </div>
         </div>
@@ -559,6 +560,7 @@ if(isset($_GET["{COLUMN_ID}"]) && !empty($_GET["{COLUMN_ID}"])){
                             <a href="{TABLE_NAME}-delete.php?{COLUMN_ID}=<?php echo $_GET["{COLUMN_ID}"];?>" class="btn btn-warning">Delete</a>
                             <a href="{TABLE_NAME}-index.php" class="btn btn-primary">Back</a>
                         </p>
+                        <p> * field can not be left empty </p>
                     </form>
                 </div>
             </div>

--- a/core/templates.php
+++ b/core/templates.php
@@ -94,7 +94,7 @@ $indexfile = <<<'EOT'
                     $where_columns = array_intersect_key($_GET, array_flip($columns));                    
                     $where_statement = " WHERE 1=1 ";
                     foreach ( $where_columns as $key => $val ) {
-                        $where_statement .= " AND $key = '$val' ";
+                        $where_statement .= " AND $key = '" . mysqli_real_escape_string($link, $val) . "' ";
                     }
 
                     // Attempt select query execution
@@ -103,7 +103,7 @@ $indexfile = <<<'EOT'
 
 
                     if(!empty($_GET['search'])) {
-                        $search = ($_GET['search']);
+                        $search = mysqli_real_escape_string($link, $_GET['search']);
                         $sql = "SELECT * FROM {TABLE_NAME}
                             $where_statement AND CONCAT_WS ({INDEX_CONCAT_SEARCH_FIELDS})
                             LIKE '%$search%'

--- a/core/templates.php
+++ b/core/templates.php
@@ -48,11 +48,9 @@ $indexfile = <<<'EOT'
                     require_once "helpers.php";
 
                     //Get current URL and parameters for correct pagination
-                    $domain   = $_SERVER['HTTP_HOST'];
                     $script   = $_SERVER['SCRIPT_NAME'];
                     $parameters   = $_GET ? $_SERVER['QUERY_STRING'] : "" ;
-                    $protocol=($_SERVER['HTTPS'] == "on" ? "https" : "http");
-                    $currenturl = $protocol . '://' . $domain. $script . '?' . $parameters;
+                    $currenturl = $domain. $script . '?' . $parameters;
 
                     //Pagination
                     if (isset($_GET['pageno'])) {


### PR DESCRIPTION
Hello all,

I have forked this repo and implemented a lot of changes. With this PR, I hope to give something back to the community.
I realise that some changes are rather big, but I still hope that others can benefit from them.

Most notably, I implemented some sort of foreign key awareness. In the creation procedure, you can select which columns should represent a foreign key record. These columns are then shown automatically when you are at the index or read page for records that refer to a foreign record. The complicated joins required for this information are generated automatically.
Other changes include:
1. Comments from the SQL Database are shown as tooltips.
2. SQL errors are shown when updating, creating or deleting a record. 
3. Make foreign key references are clickable
4. For a record that is referenced by other records, provide a link to these other records. (Visible at the bottom of a read page)
5. The update, delete and read pages now have buttons for update, deleting and reading.
6. SQL column names do not obey the same rules as PHP variable names, illegal characters are replaced with and underscore `_`.
7. SQL queries have the column names surround with ` to allow for all possible names (preventing weird SQL errors).
8. Optional (nullable) columns are properly supported.
9. The layout for read, update and create forms can be changed by changing a few lines (748-762) in `generate.php`.

There may be some minor changes that I forgot to mention.

Keep in mind that for the foreign key systems to work, you must select all tables that are participating in the relation.