### PR TITLE
Feature/import schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 core/app/
+schema/*
+!schema/.gitkeep

--- a/core/relations.php
+++ b/core/relations.php
@@ -240,7 +240,7 @@ if(isset($_POST['addkey'])){
 On this page you can add new or delete existing table relations i.e. foreign keys. Having foreign keys will result in Cruddiy forms with cascading deletes/updates and dropdown fields populated by foreign keys. If it is not clear what you want or need to do here, it is SAFER to skip this step and move to the next step! You can always come back later and regenerate new forms.
 <hr>
 <form method="post" action="tables.php" class="d-flex justify-content-between">
-    <a href="schema.php" class="btn btn-secondary">Import MySQL schema</a> <button type="submit" id="singlebutton" name="singlebutton" class="btn btn-success">Continue CRUD Creation Process</button>
+    <a href="schema.php" class="btn btn-secondary">Import Schema or Dump</a> <button type="submit" id="singlebutton" name="singlebutton" class="btn btn-success">Continue CRUD Creation Process</button>
 </form>
 </section>
 

--- a/core/relations.php
+++ b/core/relations.php
@@ -239,8 +239,8 @@ if(isset($_POST['addkey'])){
 <hr>
 On this page you can add new or delete existing table relations i.e. foreign keys. Having foreign keys will result in Cruddiy forms with cascading deletes/updates and dropdown fields populated by foreign keys. If it is not clear what you want or need to do here, it is SAFER to skip this step and move to the next step! You can always come back later and regenerate new forms.
 <hr>
-<form method="post" action="tables.php">
-    <button type="submit" id="singlebutton" name="singlebutton" class="btn btn-success">Continue CRUD Creation Process</button>
+<form method="post" action="tables.php" class="d-flex justify-content-between">
+    <a href="schema.php" class="btn btn-secondary">Import MySQL schema</a> <button type="submit" id="singlebutton" name="singlebutton" class="btn btn-success">Continue CRUD Creation Process</button>
 </form>
 </section>
 

--- a/core/relations.php
+++ b/core/relations.php
@@ -1,7 +1,7 @@
 <?php
 
 if(isset($_POST['index'])) {
-    
+
     if((isset($_POST['server'])) && $_POST['server'] <> '') {
         $server=trim($_POST['server']);
     } else {
@@ -86,7 +86,7 @@ if(isset($_POST['submit'])){
 }
 
 if(isset($_POST['addkey'])){
-    $primary = $_POST['primary'];  
+    $primary = $_POST['primary'];
     $fk = $_POST['fk'];
 
     $split_primary=explode('|', $primary);
@@ -155,9 +155,9 @@ if(isset($_POST['addkey'])){
                           <thead>
                             <tr>
                               <?php
-                                $sql = "SELECT i.TABLE_NAME as 'Table Name', k.COLUMN_NAME as 'Foreign Key', 
+                                $sql = "SELECT i.TABLE_NAME as 'Table Name', k.COLUMN_NAME as 'Foreign Key',
                                     k.REFERENCED_TABLE_NAME as 'Primary Table', k.REFERENCED_COLUMN_NAME as 'Primary Key',
-                                    i.CONSTRAINT_NAME as 'Constraint Name', 'Delete' as 'Delete' 
+                                    i.CONSTRAINT_NAME as 'Constraint Name', 'Delete' as 'Delete'
                                         FROM information_schema.TABLE_CONSTRAINTS i
                                         LEFT JOIN information_schema.KEY_COLUMN_USAGE k ON i.CONSTRAINT_NAME = k.CONSTRAINT_NAME
                                         WHERE i.CONSTRAINT_TYPE = 'FOREIGN KEY' AND i.TABLE_SCHEMA = DATABASE()";
@@ -166,7 +166,7 @@ if(isset($_POST['addkey'])){
                                     foreach ($row as $col => $value) {
                                         echo "<th>";
                                         echo $col;
-                                        echo "</th>"; 
+                                        echo "</th>";
 									}
 									echo "</thead><tbody>";
 									mysqli_data_seek($result, 0);
@@ -185,14 +185,14 @@ if(isset($_POST['addkey'])){
 												echo $row['Table Name'] .'">';
 												echo '<input type="hidden" name="fkname" value="';
 												echo $row['Constraint Name'] . '">';
-												echo "<button type='submit' id='singlebutton' name='submit' class='btn btn-danger'>Delete</button>"; 
+												echo "<button type='submit' id='singlebutton' name='submit' class='btn btn-danger'>Delete</button>";
 												echo "</form></td>";
 												echo "</tr>";
 									}
 								} else echo "</thead><tbody><tr><td>No relations found</td></tr>";
                             ?>
                                 </tbody>
-                                </table> 
+                                </table>
                 <div class="text-center">
                     <h4 class="mb-0">Add New Table Relation</h4><br>
                       <form method="post" action="<?php echo $_SERVER['PHP_SELF']; ?>">
@@ -241,7 +241,7 @@ On this page you can add new or delete existing table relations i.e. foreign key
 <hr>
 <form method="post" action="tables.php">
     <button type="submit" id="singlebutton" name="singlebutton" class="btn btn-success">Continue CRUD Creation Process</button>
-</form>     
+</form>
 </section>
 
 <script src="https://code.jquery.com/jquery-3.5.1.min.js" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>

--- a/core/schema.php
+++ b/core/schema.php
@@ -1,0 +1,82 @@
+<?php
+include "app/config.php";
+$errors = [];
+
+if(isset($_POST['submit'])){
+    $schema = $_POST['schema'];
+
+    // Turn off default exception throwing
+    mysqli_report(MYSQLI_REPORT_OFF);
+
+    try {
+        if (mysqli_multi_query($link, $schema)) {
+            do {
+                // Store and then free the result set if there is one
+                if ($result = mysqli_store_result($link)) {
+                    mysqli_free_result($result);
+                }
+            } while (mysqli_more_results($link) && mysqli_next_result($link));
+        }
+    } catch (mysqli_sql_exception $e) {
+        // Catch and store the error
+        $errors['schema'][] = $e->getMessage();
+    }
+
+    // Check for any errors that occurred after the last executed query
+    if ($error = mysqli_error($link)) {
+        $errors['schema'][] = $error;
+    }
+
+    mysqli_close($link);
+
+    if (!isset($errors['schema'])) {
+        header('location:relations.php');
+        exit();
+    }
+
+}
+?>
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>CRUD generator</title>
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css" integrity="sha384-9aIt2nRpC12Uk9gS9baDl411NQApFmC26EwAOH8WgZl5MYYxFfc+NcPb1dKGj7Sk" crossorigin="anonymous">
+
+</head>
+<body class="bg-light">
+<section class="pt-5">
+    <div class="container bg-white shadow py-5">
+        <div class="row">
+        <div class="col-md-12 mx-auto">
+            <div class="text-center">
+                <h4 class="mb-0">Import schema</h4>
+
+                <?php if (isset($errors['schema'])) : ?>
+                    <?php foreach ($errors['schema'] as $error) : ?>
+                        <div class="alert alert-danger my-3" role="alert">
+                            <?php echo $error ?>
+                        </div>
+                    <?php endforeach ?>
+                <?php endif ?>
+
+                <form method="post" action="<?php echo $_SERVER['PHP_SELF']; ?>">
+                    <div class="form-group">
+                        <label for="schema">If you have an existing schema, copy/paste it below:</label>
+                        <textarea class="form-control" name="schema" id="schema" rows="3"></textarea>
+                    </div>
+                    <button type="submit" class="btn btn-primary" name="submit">Import schema</button>
+                </form>
+            </div>
+        </div>
+        </div>
+    </div>
+</section>
+<br>
+
+<script src="https://code.jquery.com/jquery-3.5.1.min.js" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
+<script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/js/bootstrap.min.js" integrity="sha384-OgVRvuATP1z7JjHLkuOU7Xw704+h835Lr+6QL9UvYjZE3Ipu6Tp75j7Bh/kR0JKI" crossorigin="anonymous"></script>
+
+</body>
+</html>

--- a/core/schema.php
+++ b/core/schema.php
@@ -1,6 +1,8 @@
 <?php
 include "app/config.php";
+
 $errors = [];
+$schemaFiles = glob('../schema/*.sql');
 
 
 
@@ -13,7 +15,9 @@ function extractTableNames($schema) {
 
 
 if(isset($_POST['submit'])){
-    $schema = $_POST['schema'];
+    $schemaFile = $_POST['schemaFile'] ?? '';
+    $schema = $schemaFile ? file_get_contents($schemaFile) : ($_POST['schema'] ?? '');
+
     $deleteExisting = isset($_POST['deleteExisting']) ? true : false;
 
     // Turn off default exception throwing
@@ -75,34 +79,54 @@ if(isset($_POST['submit'])){
 <section class="pt-5">
     <div class="container bg-white shadow py-5">
         <div class="row">
-        <div class="col-md-12 mx-auto">
-            <div class="text-center">
-                <h4>Import schema</h4>
+            <div class="col-md-12 mx-auto">
+                <div class="text-center">
+                    <h4>Import schema</h4>
 
-                <?php if (isset($errors['schema'])) : ?>
-                    <?php foreach ($errors['schema'] as $error) : ?>
-                        <div class="alert alert-danger my-3" role="alert">
-                            <?php echo $error ?>
+                    <?php if (isset($errors['schema'])) : ?>
+                        <?php foreach ($errors['schema'] as $error) : ?>
+                            <div class="alert alert-danger my-3" role="alert">
+                                <?php echo $error ?>
+                            </div>
+                        <?php endforeach ?>
+                    <?php endif ?>
+
+
+                    <form method="post" action="<?php echo $_SERVER['PHP_SELF']; ?>">
+
+                        <!-- Dropdown for selecting a schema file -->
+                        <div class="form-group my-5">
+                            <label for="schemaFile">Select a <code>.sql</code> schema file:</label>
+                            <select class="form-control" name="schemaFile" id="schemaFile">
+                                <option value=""></option>
+                                <?php foreach ($schemaFiles as $file): ?>
+                                    <option value="<?php echo htmlspecialchars($file); ?>" <?php echo (isset($_POST['schemaFile']) && $_POST['schemaFile'] == $file) ? 'selected' : ''; ?>>
+                                        <?php echo htmlspecialchars(basename($file)); ?>
+                                    </option>
+                                <?php endforeach; ?>
+                            </select>
+                            <small id="schemaFile" class="form-text text-muted">
+                                Place your .sql files in the <code>schema/</code> folder in the project root.
+                            </small>
                         </div>
-                    <?php endforeach ?>
-                <?php endif ?>
 
-                <form method="post" action="<?php echo $_SERVER['PHP_SELF']; ?>">
-                    <div class="form-group">
-                        <label for="schema">If you have an existing schema, copy/paste it below:</label>
-                        <textarea class="form-control" name="schema" id="schema" rows="3"><?php echo isset($_POST['schema']) ? htmlspecialchars($_POST['schema']) : '' ?></textarea>
-                    </div>
-                    <div class="form-check">
-                        <input class="form-check-input" type="checkbox" value="1" id="deleteExisting" name="deleteExisting" <?php echo isset($_POST['deleteExisting']) ? 'checked="checked"' : '' ?>>
-                        <label class="form-check-label" for="deleteExisting">
-                            Disable foreign key checks and drop existing tables?
-                        </label>
-                    </div>
-                    <br>
-                    <button type="submit" class="btn btn-primary" name="submit">Import schema</button>
-                </form>
+                        <!-- Textarea for manual schema copy/paste -->
+                        <div class="form-group my-5">
+                            <label for="schema">Or copy/paste schema here:</label>
+                            <textarea class="form-control" name="schema" id="schema" rows="3"><?php echo isset($_POST['schema']) ? htmlspecialchars($_POST['schema']) : '' ?></textarea>
+                        </div>
+
+                        <div class="form-check my-5">
+                            <input class="form-check-input" type="checkbox" value="1" id="deleteExisting" name="deleteExisting" <?php echo isset($_POST['deleteExisting']) ? 'checked="checked"' : '' ?>>
+                            <label class="form-check-label" for="deleteExisting">
+                                Disable foreign key checks and drop existing tables?
+                            </label>
+                        </div>
+                        <br>
+                        <button type="submit" class="btn btn-primary" name="submit">Import schema</button>
+                    </form>
+                </div>
             </div>
-        </div>
         </div>
     </div>
 </section>


### PR DESCRIPTION
This PR is taken from master (aef1114) to avoid huge PR or breaking dependency while it is being reviewed.

I tried to commit locally it on master and got a merge conflict from PR #69  (solved by accepting the more recent version):

![](https://files.italic.fr/WinMergeU_FiypWC0vRy.png)

---

While building projects with Cruddiy, we often restart from scratch, either to regenerate CRUD forms, to update our project, get rid of test data, or to create clones of almost identical projects.

With this PR it is very easy to restart from a fresh database, or even from a dump which contains data, like user lists and default content.

Simply click on the new **Import Schema or Dump** button on the Relations page:

![](https://files.italic.fr/chrome_AliYBpLBno.png)

Now you can select a .sql file from the new root <code>schema/</code> folder, or simply copy/paste the dump.

![](https://files.italic.fr/chrome_0VJdUNXUll.png)

We are handling importation errors nicely using Bootstrap messages:

![](https://files.italic.fr/chrome_cnM9XII6kS.png)

The most frequent error is that the schema already exists, as you keep re-importing a fresh dump every time for testing. Therefore, you can force `DROP TABLE` by checking the box, and have your dump imported.

Upon successful import, the user is redirected to `redirections.php` to continue or start the mapping with the fresh schema. 