### PR TITLE
fix improper delete button label

### DIFF
--- a/core/templates.php
+++ b/core/templates.php
@@ -565,7 +565,7 @@ if(isset($_GET["{COLUMN_ID}"]) && !empty($_GET["{COLUMN_ID}"])){
                         <hr>
                         <p>
                             <a href="{TABLE_NAME}-read.php?{COLUMN_ID}=<?php echo $_GET["{COLUMN_ID}"];?>" class="btn btn-info"><?php translate('View Record') ?></a>
-                            <a href="{TABLE_NAME}-delete.php?{COLUMN_ID}=<?php echo $_GET["{COLUMN_ID}"];?>" class="btn btn-danger"><?php translate('Update Record') ?></a>
+                            <a href="{TABLE_NAME}-delete.php?{COLUMN_ID}=<?php echo $_GET["{COLUMN_ID}"];?>" class="btn btn-danger"><?php translate('Delete Record') ?></a>
                             <a href="{TABLE_NAME}-index.php" class="btn btn-primary"><?php translate('Back to List') ?></a>
                         </p>
                         <p><?php translate('required_fiels_instructions') ?></p>


### PR DESCRIPTION
Fixes regression from #82 

The "delete" button the edit pages was incorrectly labelled and colored as "updated".