### PR TITLE
fix too long column names on All Columns page

### DIFF
--- a/core/columns.php
+++ b/core/columns.php
@@ -283,7 +283,7 @@ function is_table_referenced($table_name) {
                                         ?>
 
                                         <label class="col-form-label <?= htmlspecialchars($labelClassString) ?>" for="<?= htmlspecialchars($table['name']) . '-' . $i ?>">
-                                            <abbr title="<?= htmlspecialchars($column['name']) ?>, <?php echo $column['type'] ?>"><?= truncate(htmlspecialchars($column['name']), 25) ?></abbr>
+                                            <abbr title="<?= htmlspecialchars($column['name']) ?>, <?php echo $column['type'] ?>"><?= truncate(htmlspecialchars($column['name']), 20) ?></abbr>
 
                                             <span title="<?= htmlspecialchars($labelClassString) ?>"><?= implode(' ', $labelAttributes['emojis']) ?></span>
                                         </label>


### PR DESCRIPTION
from this

![](https://files.italic.fr/chrome_k4MMcNpme5.png)

to this

![](https://files.italic.fr/chrome_NBfhxl95WX.png)