### PR TITLE
Feature/custom dest folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,10 @@
-core/app/
-
 schema/*
 !schema/.gitkeep
 !schema/Example - All field types.sql
 !schema/Example - No primary key.sql
 !schema/Tests - Admin.sql
 !schema/Tests - Public.sql
-
 tests/behat/logs/*
 !tests/behat/logs/.gitkeep
-
 /vendor/
 **/.env

--- a/core/columns.php
+++ b/core/columns.php
@@ -1,6 +1,19 @@
 <?php
-include "app/config.php";
-include "helpers.php";
+session_start();
+include 'helpers.php';
+
+if (!isset($_SESSION["destination"]) || empty($_SESSION["destination"])) {
+    // Store POST data in session
+    $_SESSION['post_data'] = $_POST;
+    header('location:directory.php?from=columns');
+    exit();
+} else {
+    include $_SESSION['destination'] . '/config.php';
+}
+
+
+// Retrieve POST data from session if needed
+$_POST = $_SESSION['post_data'] ?? null;
 
 // Debug info
 // echo '<pre>';

--- a/core/columns.php
+++ b/core/columns.php
@@ -13,7 +13,7 @@ if (!isset($_SESSION["destination"]) || empty($_SESSION["destination"])) {
 
 
 // Retrieve POST data from session if needed
-$_POST = $_SESSION['post_data'] ?? null;
+$_POST = $_SESSION['post_data'] ?? $_POST;
 
 // Debug info
 // echo '<pre>';

--- a/core/columns.php
+++ b/core/columns.php
@@ -78,8 +78,8 @@ function get_foreign_keys($table){
 
 function read_tables_and_columns_config_file() {
 
-    if (file_exists("app/config-tables-columns.php")) {
-        include("app/config-tables-columns.php");
+    if (file_exists($_SESSION['destination'] . "/config-tables-columns.php")) {
+        include($_SESSION['destination'] . "/config-tables-columns.php");
     } else {
         return null;
     }
@@ -102,8 +102,8 @@ function read_tables_and_columns_config_file() {
 $tablesData = [];
 $checked_tables_counter=0;
 if (!isset($_POST['table'])) {
-    if (file_exists("app/config-tables-columns.php")) {
-        include("app/config-tables-columns.php");
+    if (file_exists($_SESSION['destination'] . "/config-tables-columns.php")) {
+        include($_SESSION['destination'] . "/config-tables-columns.php");
         $_POST = read_tables_and_columns_config_file();
     }
 }
@@ -227,7 +227,7 @@ function is_table_referenced($table_name) {
                                 <div class="col-3"></div>
                                 <div class="col-4 my-4">
                                     <?php
-                                    $configTableNamesFilePath = 'app/config-tables-columns.php';
+                                    $configTableNamesFilePath = $_SESSION['destination'] . '/config-tables-columns.php';
                                     if (file_exists($configTableNamesFilePath)) {
                                         include($configTableNamesFilePath);
                                     }
@@ -417,7 +417,7 @@ function is_table_referenced($table_name) {
                             <div class="col-md-8 mx-auto">
                                 <p class="form-check">
                                     <small id="passwordHelpBlock" class="form-text text-muted">
-                                        Cruddiy will create a fresh startpage in the app/ sub-folder, with link<?php echo $checked_tables_counter > 1 ? 's' : '' ?> to manage the table<?php echo $checked_tables_counter > 1 ? 's' : '' ?> above.<br>
+                                        Cruddiy will create a fresh startpage in the <?php echo $_SESSION['destination'] ?>/ sub-folder, with link<?php echo $checked_tables_counter > 1 ? 's' : '' ?> to manage the table<?php echo $checked_tables_counter > 1 ? 's' : '' ?> above.<br>
                                         If you have used Cruddiy on other tables before, your start page will be replaced by the fresh one, and previous links will be lost.
                                     </small>
                                     <input class="form-check-input" type="checkbox" value="true" id="keep_startpage" name="keep_startpage">

--- a/core/directory.php
+++ b/core/directory.php
@@ -1,0 +1,81 @@
+<?php
+session_start();
+include 'helpers.php';
+
+$configDirectories = getConfigDirectories(__DIR__);
+
+// Display a message if no config.php files are found
+if (empty($configDirectories)) {
+    // echo "No configuration files found. Please ensure config.php exists in the subdirectories.";
+    header('location:index.php?generator=new');
+    exit();
+}
+
+
+// Handle form submission
+if ($_SERVER['REQUEST_METHOD'] == 'POST' && isset($_POST['configDir'])) {
+    $selectedDir = $_POST['configDir'];
+    $_SESSION['destination'] = basename($selectedDir);
+    header('location:' . $_GET['from'] . '.php');
+    exit();
+}
+?><!doctype html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <title>Select existing config</title>
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css" integrity="sha384-9aIt2nRpC12Uk9gS9baDl411NQApFmC26EwAOH8WgZl5MYYxFfc+NcPb1dKGj7Sk" crossorigin="anonymous">
+
+    <style type="text/css">
+        table tr td:last-child a {
+            margin-right: 15px;
+        }
+    </style>
+</head>
+<div class="container">
+    <div class="row">
+        <div class="col-md-6 mx-auto">
+
+            <!-- Form Name -->
+            <div class="text-center pt-5">
+                <h4>Select existing app</h4>
+            </div>
+
+            <?php if (isset($_GET["empty"])) : ?>
+                <div class="alert alert-danger" role="alert">
+                    The field <?php echo $_GET["empty"]; ?> cannot be empty.
+                </div>
+            <?php endif ?>
+
+            <form class="form-group-row" method="post">
+                <fieldset>
+
+                    <div class="form-group">
+                        <p>
+                            You have already run the Cruddiy generator.<br>
+                            Do you want to re-use an existing configuration?
+                        </p>
+
+                        <label for="configDir">Select an app:</label>
+                        <br>
+                        <select name="configDir" id="configDir">
+                            <?php if (!empty($configDirectories)): ?>
+                                <?php foreach ($configDirectories as $dir): ?>
+                                    <option value="<?php echo htmlspecialchars($dir); ?>"><?php echo htmlspecialchars($dir); ?></option>
+                                <?php endforeach; ?>
+                            <?php else: ?>
+                                <option>No configuration files found</option>
+                            <?php endif; ?>
+                        </select>
+                    </div>
+
+                    <div class="form-group d-flex justify-content-between">
+                        <input type="submit" class="btn btn-primary" value="Load Configuration">
+                        <a class="btn btn-secondary" href="index.php?generator=new">Restart from scratch</a>
+                    </div>
+                </fieldset>
+            </form>
+        </div>
+    </div>
+</div>

--- a/core/directory.php
+++ b/core/directory.php
@@ -14,9 +14,12 @@ if (empty($configDirectories)) {
 
 // Handle form submission
 if ($_SERVER['REQUEST_METHOD'] == 'POST' && isset($_POST['configDir'])) {
-    $selectedDir = $_POST['configDir'];
-    $_SESSION['destination'] = basename($selectedDir);
-    header('location:' . $_GET['from'] . '.php');
+    $_SESSION['destination'] = basename($_POST['configDir']);
+    if (isset($_GET['from']) && !empty($_GET['from'])) {
+        header('location:' . $_GET['from'] . '.php');
+    } else {
+        header('location:index.php');
+    }
     exit();
 }
 ?><!doctype html>

--- a/core/generate.php
+++ b/core/generate.php
@@ -145,6 +145,7 @@ function generate_navbar($tablename, $start_page, $keep_startpage, $append_links
     global $navbarfile;
     global $generate_start_checked_links;
     global $startpage_filename;
+    global $appname;
 
     echo "<h3>Table: $tablename</h3>";
 

--- a/core/generate.php
+++ b/core/generate.php
@@ -14,7 +14,7 @@ if (!isset($_SESSION["destination"]) || empty($_SESSION["destination"])) {
 }
 
 // Retrieve POST data from session if needed
-$_POST = $_SESSION['post_data'] ?? null;
+$_POST = $_SESSION['post_data'] ?? $_POST;
 
 // Debug POST data
 // echo '<pre>';
@@ -96,10 +96,12 @@ function column_type($columnname){
 }
 
 function is_primary_key($t, $c){
-    $cols = $_POST[$t . 'columns'];
-    foreach($cols as $col) {
-        if (isset($col['primary']) && $col['columnname'] == $c){
-            return 1;
+    $cols = isset($_POST[$t . 'columns']) ? $_POST[$t . 'columns'] : null;
+    if ($cols) {
+        foreach($cols as $col) {
+            if (isset($col['primary']) && $col['columnname'] == $c){
+                return 1;
+            }
         }
     }
     return 0;
@@ -1046,12 +1048,14 @@ function generate($postdata) {
                         }
 
                         // Define the subdirectory path from session
-                        $subdirectoryPath = $_SESSION['destination'];
+                        $subdirectoryPath = basename(__DIR__) .'/'. $_SESSION['destination'];
 
                         // Ensure the path is formatted correctly (add trailing slash if missing)
                         if (substr($subdirectoryPath, -1) != '/') {
                             $subdirectoryPath .= '/';
                         }
+
+                        $subdirectoryPath = str_replace('core/./', 'core/', $subdirectoryPath);
 
                         // Read the file into an array. Each line becomes an array element
                         $lines = file($gitignorePath, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
@@ -1065,9 +1069,9 @@ function generate($postdata) {
                             if (!in_array($subdirectoryPath, $lines)) {
                                 $lines[] = $subdirectoryPath;
                                 file_put_contents($gitignorePath, implode("\n", $lines));
-                                echo "Subdirectory path added to .gitignore.";
+                                echo "Subdirectory <code>$subdirectoryPath</code>added to .gitignore.";
                             } else {
-                                echo "Subdirectory path already exists in .gitignore.";
+                                echo "Subdirectory <code>$subdirectoryPath</code> already exists in .gitignore.";
                             }
                         } else { // If checkbox is unchecked, remove the path
                             $foundAndRemoved = false;
@@ -1080,9 +1084,9 @@ function generate($postdata) {
                             }
                             if ($foundAndRemoved) {
                                 file_put_contents($gitignorePath, implode("\n", $lines));
-                                echo "Subdirectory path removed from .gitignore.";
+                                echo "Subdirectory <code>$subdirectoryPath</code> removed from .gitignore.";
                             } else {
-                                echo "Subdirectory path not found in .gitignore.";
+                                echo "Subdirectory <code>$subdirectoryPath</code> not found in .gitignore.";
                             }
                         }
 
@@ -1256,12 +1260,21 @@ function recursiveCopy($src, $dst) {
             <div class="col-md-12 mx-auto px-5">
                 <?php generate($_POST); ?>
                 <hr>
-                <br>Your app has been created! It is completely self contained in the /app folder. You can move this folder anywhere on your server.<br><br>
-                <a href="<?php echo $_SESSION['destination'] ?>/index.php" target="_blank" rel="noopener noreferrer" class="btn btn-primary btn-lg">Go to your app &nbsp; <i class="fa fa-external-link" aria-hidden="true"></i></a><br><br>
-                You can close this tab or leave it open and use the back button to make changes and regenerate the app. Every run will overwrite the previous app unless you checked the "Keep previously generated startpage" box.<br><br>
+                <br>
+                Your app has been created! It is completely self contained in the <code><?php echo $_SESSION['destination'] ?></code> folder. You can move this folder anywhere on your server.<br><br>
+                <a href="<?php echo $_SESSION['destination'] ?>/index.php" target="_blank" rel="noopener noreferrer" class="btn btn-primary btn-lg">Go to your app &nbsp; <i class="fa fa-external-link" aria-hidden="true"></i></a>
+                <br>
+                <br>
+                You can close this tab or leave it open and use the back button to make changes and regenerate the app.
+                <br>
+                Every run will overwrite the previous app unless you checked the "Keep previously generated startpage" box.
+                <br>
+                <br>
+                Would you like to try with new settings?
+                <a href="directory.php" class="btn btn-secondary btn-sm">Restart</a>
+                <br><br>
                 <hr>
                 If you need further instructions please visit <a href="http://cruddiy.com" target="_blank">cruddiy.com</a> or ask on our <a href="https://github.com/jan-vandenberg/cruddiy" target="_blank">GitHub</a> project.
-
             </div>
         </div>
     </div>

--- a/core/generate.php
+++ b/core/generate.php
@@ -28,7 +28,7 @@ $index_table_headers = '';
 $sort = '';
 $excluded_keys = array('singlebutton', 'keep_startpage', 'append_links');
 $generate_start_checked_links = array();
-$startpage_filename = "app/navbar.php";
+$startpage_filename = $_SESSION['destination'] . "/navbar.php";
 $forced_deletion = false;
 $buttons_delimiter = '<!-- TABLE_BUTTONS -->';
 
@@ -118,7 +118,7 @@ function generate_error(){
     $prestep1 = str_replace("{CSS_REFS}", $CSS_REFS, $errorfile);
     $prestep2 = str_replace("{JS_REFS}", $JS_REFS, $prestep1);
 
-    if (!file_put_contents("app/error.php", $prestep2, LOCK_EX)) {
+    if (!file_put_contents($_SESSION['destination'] . "/error.php", $prestep2, LOCK_EX)) {
         die("Unable to open file!");
     }
     echo "Generating Error file<br>";
@@ -134,7 +134,7 @@ function generate_startpage(){
     $prestep2 = str_replace("{JS_REFS}", $JS_REFS, $prestep1);
     $prestep3 = str_replace("{APP_NAME}", $appname, $prestep2);
 
-    if (!file_put_contents("app/index.php", $prestep3, LOCK_EX)) {
+    if (!file_put_contents($_SESSION['destination'] . "/index.php", $prestep3, LOCK_EX)) {
         die("Unable to open file!");
     }
     echo "Generating main index file.<br>";
@@ -279,7 +279,7 @@ function generate_index($tablename,$tabledisplay,$index_table_headers,$index_tab
     $step9 = str_replace("{APP_NAME}", $appname, $step8 );
     $step10 = str_replace("{JOIN_COLUMNS}", $join_columns, $step9 );
     $step11 = str_replace("{JOIN_CLAUSES}", $join_clauses, $step10 );
-    if (!file_put_contents("app/".$tablename."-index.php", $step11, LOCK_EX)) {
+    if (!file_put_contents($_SESSION['destination'] . "/".$tablename."-index.php", $step11, LOCK_EX)) {
         die("Unable to open file!");
     }
     echo "Generating $tablename Index file<br>";
@@ -308,7 +308,7 @@ function generate_read($tablename, $column_id, $read_records, $foreign_key_refer
     $step3 = str_replace("{FOREIGN_KEY_REFS}", $foreign_key_references, $step2 );
     $step4 = str_replace("{JOIN_COLUMNS}", $join_columns, $step3 );
     $step5 = str_replace("{JOIN_CLAUSES}", $join_clauses, $step4 );
-    if (!file_put_contents("app/".$tablename."-read.php", $step5, LOCK_EX)) {
+    if (!file_put_contents($_SESSION['destination'] . "/".$tablename."-read.php", $step5, LOCK_EX)) {
         die("Unable to open file!");
     }
     echo "Generating $tablename Read file<br>";
@@ -333,7 +333,7 @@ function generate_delete($tablename, $column_id){
 
     $step0 = str_replace("{TABLE_NAME}", $tablename, $prestep2);
     $step1 = str_replace("{TABLE_ID}", $column_id, $step0);
-    if (!file_put_contents("app/".$tablename."-delete.php", $step1, LOCK_EX)) {
+    if (!file_put_contents($_SESSION['destination'] . "/".$tablename."-delete.php", $step1, LOCK_EX)) {
         die("Unable to open file!");
     }
     echo "Generating $tablename Delete file<br><br>";
@@ -366,7 +366,7 @@ function generate_create($tablename,$create_records, $create_err_records, $creat
     $step6 = str_replace("{CREATE_HTML}", $create_html, $step5);
     $step7 = str_replace("{CREATE_POST_VARIABLES}", $create_postvars, $step6);
     $step8 = str_replace("{COLUMN_ID}", $column_id, $step7);
-    if (!file_put_contents("app/".$tablename."-create.php", $step8, LOCK_EX)) {
+    if (!file_put_contents($_SESSION['destination'] . "/".$tablename."-create.php", $step8, LOCK_EX)) {
         die("Unable to open file!");
     }
     echo "Generating $tablename Create file<br>";
@@ -399,7 +399,7 @@ function generate_update($tablename, $create_records, $create_err_records, $crea
     $step7 = str_replace("{CREATE_POST_VARIABLES}", $create_postvars, $step6);
     $step8 = str_replace("{UPDATE_COLUMN_ROWS}", $update_column_rows, $step7);
     $step9 = str_replace("{UPDATE_SQL_COLUMNS}", $update_sql_columns, $step8);
-    if (!file_put_contents("app/".$tablename."-update.php", $step9, LOCK_EX)) {
+    if (!file_put_contents($_SESSION['destination'] . "/".$tablename."-update.php", $step9, LOCK_EX)) {
         die("Unable to open file!");
     }
     echo "Generating $tablename Update file<br>";
@@ -987,9 +987,9 @@ function generate($postdata) {
                     // force existing files deletion
                     if (!$forced_deletion && (!isset($_POST['keep_startpage']) || (isset($_POST['keep_startpage']) && $_POST['keep_startpage'] != 'true'))) {
                         $forced_deletion = true;
-                        echo '<h3>Deleting existing files in app/</h3>';
+                        echo '<h3>Deleting existing files in '. $_SESSION['destination'] .'/</h3>';
                         $keep = array('config.php', 'helpers.php', 'config-tables-columns.php', 'locales');
-                        foreach (glob("app/*") as $file) {
+                        foreach (glob($_SESSION['destination'] . "/*") as $file) {
                             if (!in_array(basename($file), $keep)) {
                                 if (is_file($file)) {
                                     if (unlink($file)) {
@@ -1004,16 +1004,16 @@ function generate($postdata) {
                         global $upload_persistent_dir;
                         echo '<h3>Deleting upload directory</h3>';
                         if (!$upload_persistent_dir) {
-                            deleteDirectory("app/$upload_target_dir");
-                            echo "app/$upload_target_dir was deleted (set <code>\$upload_persistent_dir=true</code> in app/config.php to preserve next time)";
+                            deleteDirectory($_SESSION['destination'] . "/$upload_target_dir");
+                            echo $_SESSION['destination'] . "/$upload_target_dir was deleted (set <code>\$upload_persistent_dir=true</code> in app/config.php to preserve next time)";
                         }
                         else {
-                            echo "app/$upload_target_dir was preserved due to <code>\$upload_persistent_dir=true</code> in app/config.php";
+                            echo $_SESSION['destination'] . "/$upload_target_dir was preserved due to <code>\$upload_persistent_dir=true</code> in app/config.php";
                         }
 
                         // always delete the locales directory as we may need to regenerate the translations
-                        deleteDirectory("app/locales");
-                        recursiveCopy('locales', 'app/locales');
+                        deleteDirectory($_SESSION['destination'] . "/locales");
+                        recursiveCopy('locales', $_SESSION['destination'] . '/locales');
 
                         echo '<br><br>';
 
@@ -1113,7 +1113,7 @@ function extractTableName($post_key) {
 // Save table and columns configuration
 function updateTableAndColumnsNames($tables_and_columns_names) {
 
-    $configTableNamesFilePath     = 'app/config-tables-columns.php';
+    $configTableNamesFilePath     = $_SESSION['destination'] . '/config-tables-columns.php';
     $configTableNamesTemplatePath = 'templates/config-tables-columns.php';
 
     // Read config file template
@@ -1242,7 +1242,7 @@ function recursiveCopy($src, $dst) {
                 <?php generate($_POST); ?>
                 <hr>
                 <br>Your app has been created! It is completely self contained in the /app folder. You can move this folder anywhere on your server.<br><br>
-                <a href="app/index.php" target="_blank" rel="noopener noreferrer" class="btn btn-primary btn-lg">Go to your app &nbsp; <i class="fa fa-external-link" aria-hidden="true"></i></a><br><br>
+                <a href="<?php echo $_SESSION['destination'] ?>/index.php" target="_blank" rel="noopener noreferrer" class="btn btn-primary btn-lg">Go to your app &nbsp; <i class="fa fa-external-link" aria-hidden="true"></i></a><br><br>
                 You can close this tab or leave it open and use the back button to make changes and regenerate the app. Every run will overwrite the previous app unless you checked the "Keep previously generated startpage" box.<br><br>
                 <hr>
                 If you need further instructions please visit <a href="http://cruddiy.com" target="_blank">cruddiy.com</a> or ask on our <a href="https://github.com/jan-vandenberg/cruddiy" target="_blank">GitHub</a> project.

--- a/core/generate.php
+++ b/core/generate.php
@@ -494,6 +494,7 @@ function generate($postdata) {
         global $sort;
         global $link;
         global $forced_deletion;
+        global $gitignore;
 
         if (!in_array($key, $excluded_keys)) {
             $i = 0;
@@ -1015,6 +1016,62 @@ function generate($postdata) {
                         recursiveCopy('locales', 'app/locales');
 
                         echo '<br><br>';
+
+
+
+                        echo '<h3>Updating the .gitgignore file</h3>';
+
+                        // Define the path to the .gitignore file
+                        $gitignorePath = './../.gitignore';
+
+                        // Check if the session variables are set
+                        if (!isset($gitignore) || !isset($_SESSION['destination'])) {
+                            echo "Required session variables are not set.";
+                        }
+
+                        // Define the subdirectory path from session
+                        $subdirectoryPath = $_SESSION['destination'];
+
+                        // Ensure the path is formatted correctly (add trailing slash if missing)
+                        if (substr($subdirectoryPath, -1) != '/') {
+                            $subdirectoryPath .= '/';
+                        }
+
+                        // Read the file into an array. Each line becomes an array element
+                        $lines = file($gitignorePath, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+
+                        // Check if the file was read successfully
+                        if ($lines === false) {
+                            echo "Error reading the .gitignore file.";
+                        }
+
+                        if ($gitignore) { // If checkbox is checked, add the path
+                            if (!in_array($subdirectoryPath, $lines)) {
+                                $lines[] = $subdirectoryPath;
+                                file_put_contents($gitignorePath, implode("\n", $lines));
+                                echo "Subdirectory path added to .gitignore.";
+                            } else {
+                                echo "Subdirectory path already exists in .gitignore.";
+                            }
+                        } else { // If checkbox is unchecked, remove the path
+                            $foundAndRemoved = false;
+                            foreach ($lines as $key => $line) {
+                                if (trim($line) == $subdirectoryPath) {
+                                    unset($lines[$key]);
+                                    $foundAndRemoved = true;
+                                    break; // Remove this if there could be multiple occurrences
+                                }
+                            }
+                            if ($foundAndRemoved) {
+                                file_put_contents($gitignorePath, implode("\n", $lines));
+                                echo "Subdirectory path removed from .gitignore.";
+                            } else {
+                                echo "Subdirectory path not found in .gitignore.";
+                            }
+                        }
+
+                        echo "<br><br>";
+
                     }
 
                     generate_navbar($value, $start_page, isset($_POST['keep_startpage']) && $_POST['keep_startpage'] == 'true' ? true : false, isset($_POST['append_links']) && $_POST['append_links'] == 'true' ? true : false, $tabledisplay, $key);

--- a/core/generate.php
+++ b/core/generate.php
@@ -154,7 +154,7 @@ function generate_navbar($tablename, $start_page, $keep_startpage, $append_links
             // called on the first run of the POST loop
             echo "Generating fresh Startpage file<br>";
             $step0 = str_replace("{TABLE_BUTTONS}", $start_page, $navbarfile);
-            $step1 = str_replace("{APP_NAME}", $appname, $navbarfile);
+            $step1 = str_replace("{APP_NAME}", $appname, $step0);
             if (!file_put_contents($startpage_filename, $step1, LOCK_EX)) {
                 die("Unable to open fresh startpage file!");
             }

--- a/core/generate.php
+++ b/core/generate.php
@@ -154,7 +154,8 @@ function generate_navbar($tablename, $start_page, $keep_startpage, $append_links
             // called on the first run of the POST loop
             echo "Generating fresh Startpage file<br>";
             $step0 = str_replace("{TABLE_BUTTONS}", $start_page, $navbarfile);
-            if (!file_put_contents($startpage_filename, $step0, LOCK_EX)) {
+            $step1 = str_replace("{APP_NAME}", $appname, $navbarfile);
+            if (!file_put_contents($startpage_filename, $step1, LOCK_EX)) {
                 die("Unable to open fresh startpage file!");
             }
         } else {

--- a/core/generate.php
+++ b/core/generate.php
@@ -1,4 +1,21 @@
 <?php
+session_start();
+include 'helpers.php';
+
+require 'templates.php';
+
+if (!isset($_SESSION["destination"]) || empty($_SESSION["destination"])) {
+    // Store POST data in session
+    $_SESSION['post_data'] = $_POST;
+    header('location:directory.php?from=generate');
+    exit();
+} else {
+    include $_SESSION['destination'] . '/config.php';
+}
+
+// Retrieve POST data from session if needed
+$_POST = $_SESSION['post_data'] ?? null;
+
 // Debug POST data
 // echo '<pre>';
 // print_r($_POST);
@@ -15,9 +32,8 @@ if ($total_postvars >= $max_postvars) {
     exit();
 }
 
-require "app/config.php";
-require "templates.php";
-require "helpers.php";
+
+
 $tablename = '';
 $tabledisplay = '';
 $columnname = '' ;

--- a/core/generate.php
+++ b/core/generate.php
@@ -1187,7 +1187,7 @@ function extractTableAndColumnsNames($postdata) {
 
 
 function deleteDirectory($dirPath) {
-    echo "delete : $dirPath";
+    echo "<br>Delete : $dirPath";
     if (!is_dir($dirPath)) {
         // throw new InvalidArgumentException("$dirPath must be a directory");
         return false;
@@ -1241,8 +1241,7 @@ function recursiveCopy($src, $dst) {
 }
 
 
-?>
-<!doctype html>
+?><!doctype html>
 <html lang="en">
 <head>
     <title>Generated pages</title>

--- a/core/helpers.php
+++ b/core/helpers.php
@@ -233,6 +233,38 @@ function sanitize($fileName) {
 
 
 
+function sanitizePath($path) {
+    // Split the path into segments
+    $parts = explode('/', $path);
+
+    // Sanitize each part of the path
+    foreach ($parts as &$part) {
+        // Skip special segments that reference the current or parent directory
+        if ($part === '.' || $part === '..') {
+            continue;
+        }
+
+        // Apply the same sanitization as in your original function
+        $part = str_replace(array('<', '>', ':', '"', '|', '?', '*'), '', $part);
+
+        // Normalize Unicode characters
+        if (class_exists('Normalizer')) {
+            $part = Normalizer::normalize($part, Normalizer::FORM_C);
+        }
+
+        // Replace spaces with underscores and convert to lowercase
+        $part = strtolower(str_replace(' ', '_', $part));
+
+        // Truncate to a maximum length
+        $part = substr($part, 0, 255);
+    }
+
+    // Reassemble the path
+    return implode('/', $parts);
+}
+
+
+
 function generateUniqueFileName($originalFileName) {
     $timestamp = time();
     $salt = uniqid(); // Alternatively, use bin2hex(random_bytes(8)) for more randomness

--- a/core/helpers.php
+++ b/core/helpers.php
@@ -275,3 +275,27 @@ function truncate($string, $length = 15) {
 
     return $truncated;
 }
+
+
+
+function findConfigFile() {
+
+}
+
+
+
+// Function to scan directories and find config.php
+function getConfigDirectories($baseDir, $excludedDirs = ['locales', 'templates']) {
+    $dirs = array_filter(glob($baseDir . '/*', GLOB_ONLYDIR), function ($dir) use ($excludedDirs) {
+        return !in_array(basename($dir), $excludedDirs);
+    });
+
+    $configDirs = [];
+    foreach ($dirs as $dir) {
+        if (file_exists($dir . '/config.php')) {
+            $configDirs[] = basename($dir);
+        }
+    }
+
+    return $configDirs;
+}

--- a/core/index.php
+++ b/core/index.php
@@ -1,8 +1,20 @@
 <?php
-if (file_exists("app/config.php")) {
-    include("app/config.php");
+session_start();
+include 'helpers.php';
+
+if (isset($_GET['generator']) && $_GET['generator'] == 'new') {
+    unset($_SESSION['destination']);
+} else {
+    if (isset($_SESSION["destination"]) && !empty($_SESSION["destination"])) {
+        if (file_exists($_SESSION['destination'] . '/config.php')) {
+            include $_SESSION['destination'] . '/config.php';
+        }
+    } else {
+        header('location:directory.php?from=index');
+        exit();
+    }
 }
-include("helpers.php");
+
 ?>
 <!doctype html>
 <html lang="en">

--- a/core/index.php
+++ b/core/index.php
@@ -58,9 +58,17 @@ include("helpers.php");
                         <input id="numrecordsperpage" name="numrecordsperpage" type="number" min="1" max="1000" placeholder="Number of items per page" class="form-control input-md" value="<?php echo isset($no_of_records_per_page) ? $no_of_records_per_page : 10?>">
                     </div>
 
+                    <!-- App name -->
                     <div class="form-group">
                         <label class="col-form-label" for="appname">App Name</label>
                         <input id="appname" name="appname" type="text" placeholder="Name for your app (optional)" class="form-control " value="<?php if(isset($appname)) echo $appname; ?>">
+                    </div>
+
+                    <!-- Destination folder -->
+                    <div class="form-group">
+                        <label class="col-form-label" for="destination">Destination folder</label>
+                        <input id="destination" name="destination" type="text" placeholder="./app" class="form-control " value="<?php if(isset($destination)) echo $destination; ?>">
+                        <p><small class="form-text text-muted">This is were your autonomous CRUD app will be generated.</small></p>
                     </div>
 
                     <!-- Language -->
@@ -84,7 +92,7 @@ include("helpers.php");
                             ?>
                         </select>
                         <p>
-                            <small>
+                            <small class="form-text text-muted">
                                 You can add new locales in <code>core/locales</code> (use <code>en.php</code> as starting point).
                                 Please <a href="https://github.com/jan-vandenberg/cruddiy/fork" target="_blank">fork and share</a> your translations!
                             </small>

--- a/core/index.php
+++ b/core/index.php
@@ -21,13 +21,20 @@ include("helpers.php");
 <div class="container">
     <div class="row">
         <div class="col-md-4 mx-auto">
+
+            <!-- Form Name -->
+            <div class="text-center pt-5">
+                <h4>Enter database information</h4>
+            </div>
+
+            <?php if (isset($_GET["empty"])) : ?>
+                <div class="alert alert-danger" role="alert">
+                    The field <?php echo $_GET["empty"]; ?> cannot be empty.
+                </div>
+            <?php endif ?>
+
             <form class="form-group-row" action="relations.php" method="post">
                 <fieldset>
-
-                    <!-- Form Name -->
-                    <div class="text-center pt-5">
-                        <h4>Enter database information</h4>
-                    </div>
 
                     <div class="form-group">
                         <label class="col-form-label" for="textinput">Server</label>
@@ -55,7 +62,7 @@ include("helpers.php");
                     <!-- Number records per page-->
                     <div class="form-group">
                         <label class="col-form-label" for="numrecordsperpage">Items per generated page</label>
-                        <input id="numrecordsperpage" name="numrecordsperpage" type="number" min="1" max="1000" placeholder="Number of items per page" class="form-control input-md" value="<?php echo isset($no_of_records_per_page) ? $no_of_records_per_page : 10?>">
+                        <input id="numrecordsperpage" name="numrecordsperpage" type="number" min="1" max="1000" placeholder="Number of items per page" class="form-control input-md" value="<?php if(isset($numrecordsperpage)) echo $numrecordsperpage; ?>">
                     </div>
 
                     <!-- App name -->

--- a/core/index.php
+++ b/core/index.php
@@ -85,9 +85,13 @@ if (isset($_GET['generator']) && $_GET['generator'] == 'new') {
                     <!-- Destination folder -->
                     <div class="form-group">
                         <label class="col-form-label" for="destination">Destination folder</label>
-                        <input id="destination" name="destination" type="text" placeholder="./app" class="form-control " value="<?php if(isset($destination)) echo $destination; ?>">
                         <input id="destination" name="destination" type="text" placeholder="app" class="form-control " value="<?php if(isset($destination)) echo $destination; ?>">
                         <p><small class="form-text text-muted">This is were your autonomous CRUD app will be generated.</small></p>
+                    </div>
+
+                    <div class="form-check mb-4">
+                        <input type="checkbox" class="form-check-input" id="gitignore" name="gitignore" checked>
+                        <label class="form-check-label" for="gitignore">Add to .gitignore</label>
                     </div>
 
                     <!-- Language -->

--- a/core/index.php
+++ b/core/index.php
@@ -75,6 +75,7 @@ include("helpers.php");
                     <div class="form-group">
                         <label class="col-form-label" for="destination">Destination folder</label>
                         <input id="destination" name="destination" type="text" placeholder="./app" class="form-control " value="<?php if(isset($destination)) echo $destination; ?>">
+                        <input id="destination" name="destination" type="text" placeholder="app" class="form-control " value="<?php if(isset($destination)) echo $destination; ?>">
                         <p><small class="form-text text-muted">This is were your autonomous CRUD app will be generated.</small></p>
                     </div>
 

--- a/core/index.php
+++ b/core/index.php
@@ -73,7 +73,7 @@ if (isset($_GET['generator']) && $_GET['generator'] == 'new') {
                     <!-- Number records per page-->
                     <div class="form-group">
                         <label class="col-form-label" for="numrecordsperpage">Items per generated page</label>
-                        <input id="numrecordsperpage" name="numrecordsperpage" type="number" min="1" max="1000" placeholder="Number of items per page" class="form-control input-md" value="<?php if(isset($numrecordsperpage)) echo $numrecordsperpage; ?>">
+                        <input id="numrecordsperpage" name="numrecordsperpage" type="number" min="1" max="1000" placeholder="Number of items per page" class="form-control input-md" value="<?php if(isset($no_of_records_per_page)) echo $no_of_records_per_page; ?>">
                     </div>
 
                     <!-- App name -->

--- a/core/index.php
+++ b/core/index.php
@@ -15,8 +15,7 @@ if (isset($_GET['generator']) && $_GET['generator'] == 'new') {
     }
 }
 
-?>
-<!doctype html>
+?><!doctype html>
 <html lang="en">
 
 <head>

--- a/core/index.php
+++ b/core/index.php
@@ -38,9 +38,18 @@ if (isset($_GET['generator']) && $_GET['generator'] == 'new') {
                 <h4>Enter database information</h4>
             </div>
 
+            <!-- Error messages -->
             <?php if (isset($_GET["empty"])) : ?>
                 <div class="alert alert-danger" role="alert">
                     The field <?php echo $_GET["empty"]; ?> cannot be empty.
+                </div>
+            <?php endif ?>
+
+            <?php if (isset($_GET["error"])) : ?>
+                <div class="alert alert-danger" role="alert">
+                    <?php if ($_GET['error'] == 'destination'): ?>
+                        Invalid destination name.
+                    <?php endif ?>
                 </div>
             <?php endif ?>
 
@@ -73,7 +82,7 @@ if (isset($_GET['generator']) && $_GET['generator'] == 'new') {
                     <!-- Number records per page-->
                     <div class="form-group">
                         <label class="col-form-label" for="numrecordsperpage">Items per generated page</label>
-                        <input id="numrecordsperpage" name="numrecordsperpage" type="number" min="1" max="1000" placeholder="Number of items per page" class="form-control input-md" value="<?php if(isset($no_of_records_per_page)) echo $no_of_records_per_page; ?>">
+                        <input id="numrecordsperpage" name="numrecordsperpage" type="number" min="1" max="1000" placeholder="Number of items per page (default 10)" class="form-control input-md" value="<?php if(isset($no_of_records_per_page)) echo $no_of_records_per_page; ?>">
                     </div>
 
                     <!-- App name -->
@@ -86,7 +95,11 @@ if (isset($_GET['generator']) && $_GET['generator'] == 'new') {
                     <div class="form-group">
                         <label class="col-form-label" for="destination">Destination folder</label>
                         <input id="destination" name="destination" type="text" placeholder="app" class="form-control " value="<?php if(isset($destination)) echo $destination; ?>">
-                        <p><small class="form-text text-muted">This is were your autonomous CRUD app will be generated.</small></p>
+                        <p><small class="form-text text-muted">
+                            This is were your autonomous CRUD app will be generated.
+                            <br>
+                            Relative to <code><?php echo __DIR__ ?></code>
+                        </small></p>
                     </div>
 
                     <div class="form-check mb-4">

--- a/core/relations.php
+++ b/core/relations.php
@@ -13,7 +13,7 @@ if(isset($_POST['index'])) {
 	$password          = isset($_POST['password'])          && !empty($_POST['password'])              ? trim($_POST['password'])         : null;
     $database          = isset($_POST['database'])          && !empty($_POST['database'])              ? trim($_POST['database'])         : null;
     $numrecordsperpage = isset($_POST['numrecordsperpage']) && is_numeric($_POST['numrecordsperpage']) ? $_POST['numrecordsperpage']      : 10;
-    $destination       = isset($_POST['destination'])       && !empty($_POST['destination'])           ? sanitize($_POST['destination'])  : './app';
+    $destination       = isset($_POST['destination'])       && !empty($_POST['destination'])           ? sanitizePath($_POST['destination'])  : 'app';
     $appname           = isset($_POST['appname'])           && !empty($_POST['appname'])               ? $_POST['appname']                : 'Database Admin';
     $language          = isset($_POST['language'])          && !empty($_POST['language'])              ? $_POST['language']               : 'en';
     $gitignore         = isset($_POST['gitignore'])                                                    ? true                             : false;
@@ -31,6 +31,16 @@ if(isset($_POST['index'])) {
     if (!$password) header('location:index.php?empty=Password');
     if (!$database) header('location:index.php?empty=Database');
 
+    $reserved_words = array(
+        'templates',
+        'locales',
+        '../core',
+        '../schema',
+        '../tests',
+    );
+    if (in_array($destination, $reserved_words)) {
+        header('location:index.php?error=destination');
+    }
 
     /* Attempt to connect to MySQL database */
 	$link = mysqli_connect($server, $username, $password, $database);

--- a/core/relations.php
+++ b/core/relations.php
@@ -1,6 +1,6 @@
 <?php
 session_start();
-include('helpers.php');
+include 'helpers.php';
 
 if(isset($_POST['index'])) {
 

--- a/core/relations.php
+++ b/core/relations.php
@@ -43,8 +43,15 @@ if(isset($_POST['index'])) {
 		$_POST[$k] = mysqli_real_escape_string($link, $v);
 	}
 
-	if (!file_exists('./app'))
-		mkdir('./app', 0777, true);
+    // TODO: error handling if $destination cannot be created
+	if (!file_exists($destination)) {
+		mkdir($destination, 0777, true);
+    }
+
+
+    $_SESSION['destination'] = $destination;
+    $configfilePath = $destination . '/config.php';
+    $_SESSION['gitignore'] = $gitignore;
 
 
     $helpersfilename = 'helpers.php';
@@ -52,7 +59,7 @@ if(isset($_POST['index'])) {
     $helpers = fread($handle, filesize($helpersfilename));
     fclose($handle);
 
-    $helpersfile = fopen("app/".$helpersfilename, "w") or die("Unable to create Helpers file! Please check your file permissions");
+    $helpersfile = fopen($destination . '/'. $helpersfilename, "w") or die("Unable to create Helpers file! Please check your file permissions");
     fwrite($helpersfile, $helpers);
 	fclose($helpersfile);
 
@@ -85,6 +92,8 @@ if(isset($_POST['index'])) {
     if (fwrite($configfile, $templateContent) === false) die("Error writing Config file!");
     fclose($configfile);
 
+} else {
+    $configfilePath = $_SESSION['destination'] . '/config.php';
 }
 require $configfilePath;
 

--- a/core/relations.php
+++ b/core/relations.php
@@ -37,6 +37,7 @@ if(isset($_POST['index'])) {
         '../core',
         '../schema',
         '../tests',
+        '../vendor',
     );
     if (in_array($destination, $reserved_words)) {
         header('location:index.php?error=destination');

--- a/core/relations.php
+++ b/core/relations.php
@@ -3,27 +3,28 @@ $configfilePath = 'app/config.php';
 
 if(isset($_POST['index'])) {
 
-    if((isset($_POST['server'])) && $_POST['server'] <> '') {
-        $server=trim($_POST['server']);
-    } else {
-        $server = "localhost";
-    }
-	if(isset($_POST['username'])) $username=trim($_POST['username']);
-	if(isset($_POST['password'])) $password=trim($_POST['password']);
-	if(isset($_POST['database'])) $database=trim($_POST['database']);
-	if(isset($_POST['numrecordsperpage'])) $numrecordsperpage=$_POST['numrecordsperpage'];
+	$server            = isset($_POST['server'])            && !empty($_POST['server'])                ? trim($_POST['server'])      : 'localhost';
+	$username          = isset($_POST['username'])          && !empty($_POST['username'])              ? trim($_POST['username'])    : null;
+	$password          = isset($_POST['password'])          && !empty($_POST['password'])              ? trim($_POST['password'])    : null;
+    $database          = isset($_POST['database'])          && !empty($_POST['database'])              ? trim($_POST['database'])    : null;
+    $numrecordsperpage = isset($_POST['numrecordsperpage']) && is_numeric($_POST['numrecordsperpage']) ? $_POST['numrecordsperpage'] : 10;
+    $destination       = isset($_POST['destination'])       && !empty($_POST['destination'])           ? $_POST['destination']       : './app';
+    $appname           = isset($_POST['$appname'])          && !empty($_POST['$appname'])              ? $_POST['$appname']          : 'Database Admin';
+    $language          = isset($_POST['$language'])         && !empty($_POST['$language'])             ? $_POST['$language']         : 'en';
 
-    if((isset($_POST['appname'])) && $_POST['appname'] <> '') {
-        $appname=trim($_POST['appname']);
-    } else {
-        $appname = "Database Admin";
-    }
+    // echo "server: $server<br>";
+    // echo "username: $username<br>";
+    // echo "password: $password<br>";
+    // echo "database: $database<br>";
+    // echo "numrecordsperpage: $numrecordsperpage<br>";
+    // echo "destination: $destination<br>";
+    // echo "appname: $appname<br>";
+    // echo "language: $language<br>";
 
-    if((isset($_POST['language'])) && !is_numeric($_POST['language'])) {
-        $language=$_POST['language'];
-    } else {
-        $language = "en";
-    }
+    if (!$username) header('location:index.php?empty=Username');
+    if (!$password) header('location:index.php?empty=Password');
+    if (!$database) header('location:index.php?empty=Database');
+
 
     /* Attempt to connect to MySQL database */
 	$link = mysqli_connect($server, $username, $password, $database);
@@ -36,8 +37,8 @@ if(isset($_POST['index'])) {
 		$_POST[$k] = mysqli_real_escape_string($link, $v);
 	}
 
-	if (!file_exists('app'))
-		mkdir('app', 0777, true);
+	if (!file_exists('./app'))
+		mkdir('./app', 0777, true);
 
 
     $helpersfilename = 'helpers.php';

--- a/core/relations.php
+++ b/core/relations.php
@@ -18,14 +18,14 @@ if(isset($_POST['index'])) {
     $language          = isset($_POST['language'])          && !empty($_POST['language'])              ? $_POST['language']               : 'en';
     $gitignore         = isset($_POST['gitignore'])                                                    ? true                             : false;
 
-    echo "server: $server<br>";
-    echo "username: $username<br>";
-    echo "password: $password<br>";
-    echo "database: $database<br>";
-    echo "numrecordsperpage: $numrecordsperpage<br>";
-    echo "destination: $destination<br>";
-    echo "appname: $appname<br>";
-    echo "language: $language<br>";
+    // echo "server: $server<br>";
+    // echo "username: $username<br>";
+    // echo "password: $password<br>";
+    // echo "database: $database<br>";
+    // echo "numrecordsperpage: $numrecordsperpage<br>";
+    // echo "destination: $destination<br>";
+    // echo "appname: $appname<br>";
+    // echo "language: $language<br>";
 
     if (!$username) header('location:index.php?empty=Username');
     if (!$password) header('location:index.php?empty=Password');
@@ -186,8 +186,7 @@ if(isset($_POST['addkey'])){
     }
 }
 
-?>
-<!doctype html>
+?><!doctype html>
 <html lang="en">
 <head>
     <title>Select Relations</title>

--- a/core/relations.php
+++ b/core/relations.php
@@ -1,25 +1,31 @@
 <?php
-$configfilePath = 'app/config.php';
+session_start();
+include('helpers.php');
 
 if(isset($_POST['index'])) {
 
-	$server            = isset($_POST['server'])            && !empty($_POST['server'])                ? trim($_POST['server'])      : 'localhost';
-	$username          = isset($_POST['username'])          && !empty($_POST['username'])              ? trim($_POST['username'])    : null;
-	$password          = isset($_POST['password'])          && !empty($_POST['password'])              ? trim($_POST['password'])    : null;
-    $database          = isset($_POST['database'])          && !empty($_POST['database'])              ? trim($_POST['database'])    : null;
-    $numrecordsperpage = isset($_POST['numrecordsperpage']) && is_numeric($_POST['numrecordsperpage']) ? $_POST['numrecordsperpage'] : 10;
-    $destination       = isset($_POST['destination'])       && !empty($_POST['destination'])           ? $_POST['destination']       : './app';
-    $appname           = isset($_POST['$appname'])          && !empty($_POST['$appname'])              ? $_POST['$appname']          : 'Database Admin';
-    $language          = isset($_POST['$language'])         && !empty($_POST['$language'])             ? $_POST['$language']         : 'en';
+    // echo '<pre>';
+    // print_r($_POST);
+    // echo '</pre>';
 
-    // echo "server: $server<br>";
-    // echo "username: $username<br>";
-    // echo "password: $password<br>";
-    // echo "database: $database<br>";
-    // echo "numrecordsperpage: $numrecordsperpage<br>";
-    // echo "destination: $destination<br>";
-    // echo "appname: $appname<br>";
-    // echo "language: $language<br>";
+	$server            = isset($_POST['server'])            && !empty($_POST['server'])                ? trim($_POST['server'])           : 'localhost';
+	$username          = isset($_POST['username'])          && !empty($_POST['username'])              ? trim($_POST['username'])         : null;
+	$password          = isset($_POST['password'])          && !empty($_POST['password'])              ? trim($_POST['password'])         : null;
+    $database          = isset($_POST['database'])          && !empty($_POST['database'])              ? trim($_POST['database'])         : null;
+    $numrecordsperpage = isset($_POST['numrecordsperpage']) && is_numeric($_POST['numrecordsperpage']) ? $_POST['numrecordsperpage']      : 10;
+    $destination       = isset($_POST['destination'])       && !empty($_POST['destination'])           ? sanitize($_POST['destination'])  : './app';
+    $appname           = isset($_POST['appname'])           && !empty($_POST['appname'])               ? $_POST['appname']                : 'Database Admin';
+    $language          = isset($_POST['language'])          && !empty($_POST['language'])              ? $_POST['language']               : 'en';
+    $gitignore         = isset($_POST['gitignore'])                                                    ? true                             : false;
+
+    echo "server: $server<br>";
+    echo "username: $username<br>";
+    echo "password: $password<br>";
+    echo "database: $database<br>";
+    echo "numrecordsperpage: $numrecordsperpage<br>";
+    echo "destination: $destination<br>";
+    echo "appname: $appname<br>";
+    echo "language: $language<br>";
 
     if (!$username) header('location:index.php?empty=Username');
     if (!$password) header('location:index.php?empty=Password');
@@ -67,6 +73,8 @@ if(isset($_POST['index'])) {
         '{{no_of_records_per_page}}' => $numrecordsperpage,
         '{{appname}}'                => $appname,
         '{{language}}'               => $language,
+        '{{gitignore}}'              => $gitignore,
+        '{{destination}}'            => $destination,
     ];
 
     foreach ($replacements as $placeholder => $realValue) {

--- a/core/schema.php
+++ b/core/schema.php
@@ -1,5 +1,7 @@
 <?php
-include "app/config.php";
+session_start();
+
+include $_SESSION['destination'] . '/config.php';
 include "helpers.php";
 
 $errors = [];

--- a/core/schema.php
+++ b/core/schema.php
@@ -1,8 +1,8 @@
 <?php
 session_start();
+include 'helpers.php';
 
 include $_SESSION['destination'] . '/config.php';
-include "helpers.php";
 
 $errors = [];
 $schemaFiles = glob('../schema/*.sql');

--- a/core/schema.php
+++ b/core/schema.php
@@ -69,8 +69,7 @@ if(isset($_POST['submit'])){
         exit();
     }
 }
-?>
-<!doctype html>
+?><!doctype html>
 <html lang="en">
 <head>
     <meta charset="UTF-8">

--- a/core/tables.php
+++ b/core/tables.php
@@ -1,10 +1,18 @@
-    <?php
-    include "app/config.php";
-    include "helpers.php";
+<?php
+session_start();
+include 'helpers.php';
+
+    if (isset($_SESSION["destination"]) && !empty($_SESSION["destination"])) {
+        include $_SESSION['destination'] . '/config.php';
+    } else {
+        header('location:directory.php?from=tables');
+        exit();
+    }
+
 
     $tables_and_columns_names = [];
-    if (file_exists("app/config-tables-columns.php")) {
-        include("app/config-tables-columns.php");
+    if (isset($_SESSION['destination']) && file_exists($_SESSION['destination'] . '/config-tables-columns.php')) {
+        include($_SESSION['destination'] . '/config-tables-columns.php');
     }
     ?>
     <!doctype html>
@@ -44,11 +52,6 @@
                             while($cRow = mysqli_fetch_array($res))
                             {
                                 $tablelist[] = $cRow[0];
-                            }
-
-                            $configTableNamesFilePath = 'app/config-tables-columns.php';
-                            if (file_exists($configTableNamesFilePath)) {
-                                include($configTableNamesFilePath);
                             }
                             ?>
 

--- a/core/tables.php
+++ b/core/tables.php
@@ -52,6 +52,11 @@ if (isset($_SESSION['destination']) && file_exists($_SESSION['destination'] . '/
                             {
                                 $tablelist[] = $cRow[0];
                             }
+
+                            $configTableNamesFilePath = $_SESSION["destination"] . '/config-tables-columns.php';
+                            if (file_exists($configTableNamesFilePath)) {
+                                include($configTableNamesFilePath);
+                            }
                             ?>
 
                             <div class="container">

--- a/core/tables.php
+++ b/core/tables.php
@@ -2,20 +2,19 @@
 session_start();
 include 'helpers.php';
 
-    if (isset($_SESSION["destination"]) && !empty($_SESSION["destination"])) {
-        include $_SESSION['destination'] . '/config.php';
-    } else {
-        header('location:directory.php?from=tables');
-        exit();
-    }
+if (isset($_SESSION["destination"]) && !empty($_SESSION["destination"])) {
+    include $_SESSION['destination'] . '/config.php';
+} else {
+    header('location:directory.php?from=tables');
+    exit();
+}
 
 
-    $tables_and_columns_names = [];
-    if (isset($_SESSION['destination']) && file_exists($_SESSION['destination'] . '/config-tables-columns.php')) {
-        include($_SESSION['destination'] . '/config-tables-columns.php');
-    }
-    ?>
-    <!doctype html>
+$tables_and_columns_names = [];
+if (isset($_SESSION['destination']) && file_exists($_SESSION['destination'] . '/config-tables-columns.php')) {
+    include($_SESSION['destination'] . '/config-tables-columns.php');
+}
+?><!doctype html>
     <html lang="en">
     <head>
         <meta charset="UTF-8">

--- a/core/templates/config.php
+++ b/core/templates/config.php
@@ -6,6 +6,8 @@ $db_user                = '{{db_user}}';
 $db_password            = '{{db_password}}';
 $no_of_records_per_page = '{{no_of_records_per_page}}';
 $appname                = '{{appname}}';
+$gitignore              = '{{gitignore}}';
+$destination            = '{{destination}}';
 $language               = '{{language}}';
 $translations           = include("locales/$language.php");
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -19,13 +19,13 @@ composer install
 - If your test user does not have the privileges to create a database, just create it and fill the credentials in the `.env`. If the database exists, we will not attempt to re-create it.
 
 
-## 1.3. Run all tests
+## 1.3. Run all tests (all suites)
 
 Go to the root directory of the project and run `vendor/bin/behat --config tests/behat/behat.yml`
 
 ```
 germain@nuc13 UCRT64 /d/Sites/cruddiy
-$ vendor/bin/behat --config tests/behat/behat.yml --suite admin
+$ vendor/bin/behat --config tests/behat/behat.yml  --stop-on-failure
    (...)
 
 47 scénarios (47 succès)
@@ -33,7 +33,7 @@ $ vendor/bin/behat --config tests/behat/behat.yml --suite admin
 0m46.61s (13.23Mb)
 ```
 
-## 1.4. Run a specific suite
+## 1.4. Run a specific suite of tests
 
 - **Admin suite**: simulate the creation of a fresh CRUD
 - **Public suite**: impersonate a user navigating on the generated CRUD pages
@@ -43,6 +43,7 @@ $ vendor/bin/behat --config tests/behat/behat.yml --suite admin
 ```
 vendor/bin/behat --config tests/behat/behat.yml --suite admin
 vendor/bin/behat --config tests/behat/behat.yml --suite public
+vendor/bin/behat --config tests/behat/behat.yml --suite regenerate_nogitignore
 vendor/bin/behat --config tests/behat/behat.yml --suite regenerate
 vendor/bin/behat --config tests/behat/behat.yml --suite public # or public_after_regenerate, it's a copy
 ```
@@ -114,6 +115,7 @@ vendor/bin/behat --config tests/behat/behat.yml --dry-run --no-snippets \
 - The name of the log file mimics the Behat files in the `features/` directory, eg.:
   - Step fails in tests\behat\features\admin\relations\schema.feature line 16
   - Name of the log file: admin_relations_schema-16.html
+- There is also a custom step definition **Then I log the content of the page** that will log a page even if there is no error
 
 
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -53,6 +53,13 @@ vendor/bin/behat --config tests/behat/behat.yml --suite public # or public_after
 vendor/bin/behat --config tests/behat/behat.yml tests/behat/features/admin/relations/schema.feature
 ```
 
+## 1.6. Stop on failure
+
+You can stop the tests when the first failure arises:
+
+```
+vendor/bin/behat --config tests/behat/behat.yml --suite admin --stop-on-failure
+```
 
 
 

--- a/tests/behat/behat.yml
+++ b/tests/behat/behat.yml
@@ -16,11 +16,11 @@ default:
         - features/admin/relations/form.fill.feature
         - features/admin/tables/page.feature
         - features/admin/tables/form.fill.feature
-        - features/admin/columns/page.feature
         - features/admin/columns/form.feature
         - features/admin/columns/form.fresh.feature
         - features/admin/columns/form.fill.feature
         - features/admin/generate/page.feature
+        - features/admin/generate/gitignore.added.feature
         - features/admin/generate/result.feature
 
 
@@ -38,22 +38,42 @@ default:
 
 
 
-    # Test an existing installation (the generator was run at least once)
+    # Test an existing installation (the generator was run at least once) but uncheck gitignore
+    regenerate_nogitignore:
+      contexts:
+        - AdminFeatureContext: []
+      paths:
+        - features/admin/index/page.regenerate.feature
+        - features/admin/index/form.submit.nogitignore.feature
+        - features/admin/relations/page.feature
+        - features/admin/relations/form.feature
+        - features/admin/tables/page.feature
+        - features/admin/tables/form.reconfigure.feature
+        - features/admin/tables/form.submit.feature
+        - features/admin/columns/form.feature
+        - features/admin/columns/form.reconfigure.feature
+        - features/admin/generate/page.feature
+        - features/admin/generate/gitignore.removed.feature
+        - features/admin/generate/result.feature
+
+
+
+  # Test an existing installation (same as above, but recheck gitignore)
     regenerate:
       contexts:
         - AdminFeatureContext: []
       paths:
-        - features/admin/index/page.feature
+        - features/admin/index/page.regenerate.feature
         - features/admin/index/form.submit.feature
         - features/admin/relations/page.feature
         - features/admin/relations/form.feature
         - features/admin/tables/page.feature
         - features/admin/tables/form.reconfigure.feature
         - features/admin/tables/form.submit.feature
-        - features/admin/columns/page.feature
         - features/admin/columns/form.feature
         - features/admin/columns/form.reconfigure.feature
         - features/admin/generate/page.feature
+        - features/admin/generate/gitignore.kept.feature
         - features/admin/generate/result.feature
 
 
@@ -68,6 +88,7 @@ default:
         - features/public/create.feature
         - features/public/update.feature
         - features/public/delete.feature
+
 
 
   extensions:

--- a/tests/behat/features/admin/columns/form.fill.feature
+++ b/tests/behat/features/admin/columns/form.fill.feature
@@ -3,7 +3,6 @@ Feature: Fill admin columns form
   Scenario: Set values
 
     And I fill in "text-brands-name" with "Brand name"
-
     And I fill in "text-products-ean" with "EAN-13"
     And I fill in "text-products-product_name" with "Product name"
     And I fill in "text-products-brand_id" with "Brand"
@@ -27,5 +26,8 @@ Feature: Fill admin columns form
 
     And I press "Generate Pages"
 
-    Then I should not see "Parse error"
-    And I should not see "Fatal error"
+    Then I should see "Select existing app"
+    And I select "app_cruddiy_tests" from "configDir"
+    And I press "Load Configuration"
+
+    Then I should see "Your app has been created!"

--- a/tests/behat/features/admin/columns/form.reconfigure.feature
+++ b/tests/behat/features/admin/columns/form.reconfigure.feature
@@ -99,5 +99,9 @@ Feature: Check field default values
     # submit form
     And I press "Generate Pages"
 
+    Then I should see "Select existing app"
+    And I select "app_cruddiy_tests" from "configDir"
+    And I press "Load Configuration"
+
     Then I should not see "Parse error"
     And I should not see "Fatal error"

--- a/tests/behat/features/admin/columns/page.feature
+++ b/tests/behat/features/admin/columns/page.feature
@@ -1,7 +1,0 @@
-Feature: Check admin columns page
-
-  Scenario: Check for errors on the Columns page
-    Then I should see "All Available Columns"
-    And I should not see "Parse error"
-    And I should not see "Fatal error"
-

--- a/tests/behat/features/admin/generate/gitignore.added.feature
+++ b/tests/behat/features/admin/generate/gitignore.added.feature
@@ -1,0 +1,8 @@
+Feature: Check .gitignore file
+
+  Scenario: Check confirmation message on generate
+    And I should see "Subdirectory path added to .gitignore."
+
+  Scenario: Check for the existence of destination subdirectory in .gitignore
+    Given I have a .gitignore file
+    Then I check for "app_cruddiy_tests/" in the .gitignore file

--- a/tests/behat/features/admin/generate/gitignore.kept.feature
+++ b/tests/behat/features/admin/generate/gitignore.kept.feature
@@ -1,0 +1,8 @@
+Feature: Check .gitignore file
+
+  Scenario: Check confirmation message on generate
+    And I should see either "Subdirectory path already exists in .gitignore." or "Subdirectory path added to .gitignore."
+
+  Scenario: Check for the existence of destination subdirectory in .gitignore
+    Given I have a .gitignore file
+    Then I check for "app_cruddiy_tests/" in the .gitignore file

--- a/tests/behat/features/admin/generate/gitignore.removed.feature
+++ b/tests/behat/features/admin/generate/gitignore.removed.feature
@@ -1,0 +1,9 @@
+Feature: Check .gitignore file
+
+  Scenario: Check confirmation message on generate
+    And I should see either "Subdirectory path removed from .gitignore." or "Subdirectory path not found in .gitignore."
+
+
+  Scenario: Check for the existence of destination subdirectory in .gitignore
+    Given I have a .gitignore file
+    Then I check for no "app_cruddiy_tests/" in the .gitignore file

--- a/tests/behat/features/admin/generate/page.feature
+++ b/tests/behat/features/admin/generate/page.feature
@@ -10,3 +10,5 @@ Feature: Check the generator execution
     And I should not see "Fatal error"
 
     And I should see "Your app has been created!"
+
+    # Then I log the content of the page

--- a/tests/behat/features/admin/index/deconfigure.feature
+++ b/tests/behat/features/admin/index/deconfigure.feature
@@ -10,3 +10,4 @@ Feature: Reset the installation
     And the "numrecordsperpage" field should contain ""
     And the "appname" field should contain ""
     And the "language" field should contain "en"
+    And the checkbox "gitignore" should be checked

--- a/tests/behat/features/admin/index/deconfigure.feature
+++ b/tests/behat/features/admin/index/deconfigure.feature
@@ -7,6 +7,6 @@ Feature: Reset the installation
     And the "database" field should contain ""
     And the "username" field should contain ""
     And the "password" field should contain ""
-    And the "numrecordsperpage" field should contain "10"
+    And the "numrecordsperpage" field should contain ""
     And the "appname" field should contain ""
     And the "language" field should contain "en"

--- a/tests/behat/features/admin/index/form.fill.feature
+++ b/tests/behat/features/admin/index/form.fill.feature
@@ -10,6 +10,8 @@ Feature: Fill the form
 
     And I fill in "numrecordsperpage" with "2"
     And I fill in "appname" with "Cruddiy Tests"
+    And I fill in "destination" with "app_cruddiy_tests"
+    And I check "gitignore"
     And I fill in "language" with "en"
 
     And I press "Submit"

--- a/tests/behat/features/admin/index/form.submit.nogitignore.feature
+++ b/tests/behat/features/admin/index/form.submit.nogitignore.feature
@@ -1,6 +1,8 @@
 Feature: The form should be pre-field
 
-  Scenario: Look for config file variables
+  Scenario: Look for config file variables and uncheck gitignore
+
+    And I uncheck "gitignore"
 
     And I press "Submit"
     Then I should not see "Access denied"

--- a/tests/behat/features/admin/index/page.regenerate.feature
+++ b/tests/behat/features/admin/index/page.regenerate.feature
@@ -1,0 +1,30 @@
+Feature: Check admin index page content when regenerating CRUD
+
+    Scenario: Existing configuration was detected
+        Given I am on "/core/index.php"
+        Then I should see "Select existing app"
+
+
+
+    Scenario: Restart configuration from scratch
+        Given I am on "/core/index.php"
+            And I follow "Restart from scratch"
+            Then I should see "Enter database information"
+
+
+
+    Scenario: Re-using an existing configuration
+        Given I am on "/core/index.php"
+            And I select "app_cruddiy_tests" from "configDir"
+            And I press "Load Configuration"
+
+            Then the "server" field should contain "localhost"
+            And the "database" field should contain "cruddiy_tests"
+            And the "username" field should contain "root"
+            And the "password" field should contain "root"
+            And the "numrecordsperpage" field should contain "2"
+            And the "appname" field should contain "Cruddiy Tests"
+            And the "destination" field should contain "app_cruddiy_tests"
+            And the "gitignore" checkbox should be checked
+            And the "language" field should contain "en"
+

--- a/tests/behat/features/admin/relations/schema.feature
+++ b/tests/behat/features/admin/relations/schema.feature
@@ -8,7 +8,7 @@ Feature: Check admin schema import form
     And I should not see "Fatal error"
 
   Scenario: Check schema import form
-    Given I am on "/core/schema.php"
+    # Given I am on "/core/schema.php"
     When I select "../schema/Tests - Admin.sql" from "schemaFile"
 
     And I press "Import schema"

--- a/tests/behat/features/admin/tables/form.fill.feature
+++ b/tests/behat/features/admin/tables/form.fill.feature
@@ -1,7 +1,6 @@
 Feature: Check admin tables mapping form
 
   Scenario: Fill the tables form
-    Given I am on "/core/tables.php"
 
     And the "generate-brands" checkbox should not be checked
     And the "generate-products" checkbox should not be checked
@@ -11,14 +10,18 @@ Feature: Check admin tables mapping form
     And the "text-products" field should contain ""
     And the "text-suppliers" field should contain ""
 
-    And I fill in "text-brands" with "The Brands"
     And I check "generate-brands"
-
-    And I fill in "text-products" with "The Products"
     And I check "generate-products"
-
-    And I fill in "text-suppliers" with "The Suppliers"
     And I check "generate-suppliers"
 
-    And I press "Select columns from tables"
-    And I should see "The Suppliers (suppliers)"
+    And I fill in "text-brands" with "The Brands"
+    And I fill in "text-products" with "The Products"
+    And I fill in "text-suppliers" with "The Suppliers"
+
+    When I press "Select columns from tables"
+
+    Then I should see "Select existing app"
+    And I select "app_cruddiy_tests" from "configDir"
+    And I press "Load Configuration"
+
+    # Then I log the content of the page

--- a/tests/behat/features/admin/tables/form.reconfigure.feature
+++ b/tests/behat/features/admin/tables/form.reconfigure.feature
@@ -4,6 +4,9 @@ Feature: Check admin tables page
   Scenario: Check for preconfiguration from config-tables-columns.php
     Given I am on "/core/tables.php"
 
+    And I select "app_cruddiy_tests" from "configDir"
+    And I press "Load Configuration"
+
     Then the "text-brands" field should contain "The Brands"
     And the "text-products" field should contain "The Products"
     And the "text-suppliers" field should contain "The Suppliers"

--- a/tests/behat/features/admin/tables/form.submit.feature
+++ b/tests/behat/features/admin/tables/form.submit.feature
@@ -1,6 +1,9 @@
 Feature: Check admin tables mapping form
 
   Scenario: Submit the form with preconfigured values
-    Given I am on "/core/tables.php"
-
     And I press "Select columns from tables"
+
+    And I select "app_cruddiy_tests" from "configDir"
+    And I press "Load Configuration"
+
+    # Then I log the content of the page

--- a/tests/behat/features/admin/tables/page.feature
+++ b/tests/behat/features/admin/tables/page.feature
@@ -5,7 +5,11 @@ Feature: Check admin tables page
     Then I should not see "Parse error"
     And I should not see "Fatal error"
 
-    And I should see "All Available Tables"
+    And I should see "Select existing app"
+    And I select "app_cruddiy_tests" from "configDir"
+    And I press "Load Configuration"
+
+    Then I should see "All Available Tables"
     And I should see "brands"
     And I should see "products"
     And I should see "suppliers"

--- a/tests/behat/features/bootstrap/AdminFeatureContext.php
+++ b/tests/behat/features/bootstrap/AdminFeatureContext.php
@@ -9,6 +9,8 @@ use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 
 class AdminFeatureContext extends FeatureContext implements Context {
 
+    private $gitignoreContent;
+
     /**
      * @BeforeScenario @deconfigure
     */
@@ -16,7 +18,34 @@ class AdminFeatureContext extends FeatureContext implements Context {
         $this->resetDatabase();
         $this->deleteTablesColumnsConfig();
         $this->deleteTestUploads();
+        $this->removeDestinationFromGitignore();
     }
+
+
+
+    public function removeDestinationFromGitignore() {
+        $gitignorePath = __DIR__ . '/../../../../.gitignore';
+        $stringToRemove = "app_cruddiy_tests/";
+
+        // Read the file into an array. Each line becomes an array element
+        $lines = file($gitignorePath, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+
+        // Check if the file was read successfully
+        if ($lines === false) {
+            die("Error reading the .gitignore file.");
+        }
+
+        // Remove the line containing the specific string
+        $lines = array_filter($lines, function($line) use ($stringToRemove) {
+            return trim($line) !== $stringToRemove;
+        });
+
+        // Write the remaining lines back to the file
+        file_put_contents($gitignorePath, implode("\n", $lines));
+
+        echo "Removed $stringToRemove from .gitignore file.";
+    }
+
 
 
     public function resetDatabase() {
@@ -36,7 +65,7 @@ class AdminFeatureContext extends FeatureContext implements Context {
 
 
     public function deleteTablesColumnsConfig() {
-        $directory = __DIR__ . '/../../../../core/app/';
+        $directory = __DIR__ . '/../../../../core/app_cruddiy_tests/';
         $files = array('config.php', 'config-tables-columns.php');
         foreach ($files as $file) {
             if (file_exists($directory . $file)) {
@@ -46,5 +75,38 @@ class AdminFeatureContext extends FeatureContext implements Context {
     }
 
 
+
+    /**
+     * @Given I have a .gitignore file
+     */
+    public function iHaveAGitignoreFile()
+    {
+        // Adjust the path to your .gitignore file
+        $gitignorePath = __DIR__ . '/../../../../.gitignore';
+        if (!file_exists($gitignorePath)) {
+            throw new Exception(".gitignore file does not exist in $gitignorePath");
+        }
+        $this->gitignoreContent = file_get_contents($gitignorePath);
+    }
+
+    /**
+     * @When I check for :subdirectory in the .gitignore file
+     */
+    public function iCheckForInTheGitignoreFile($subdirectory)
+    {
+        if (strpos($this->gitignoreContent, $subdirectory) === false) {
+            throw new Exception("Subdirectory $subdirectory not found in .gitignore.");
+        }
+    }
+
+    /**
+     * @When I check for no :subdirectory in the .gitignore file
+     */
+    public function iCheckForNoInTheGitignoreFile($subdirectory)
+    {
+        if (!strpos($this->gitignoreContent, $subdirectory) === false) {
+            throw new Exception("Subdirectory $subdirectory was found in .gitignore.");
+        }
+    }
 
 }

--- a/tests/behat/features/bootstrap/PublicFeatureContext.php
+++ b/tests/behat/features/bootstrap/PublicFeatureContext.php
@@ -22,7 +22,7 @@ class PublicFeatureContext extends FeatureContext implements Context {
     public function importTablesColumnsConfig() {
         $root = __DIR__ . '/../../../..';
         $sourceFile = $root . '/tests/templates/config-tables-columns.php';
-        $destinationFile = $root . '/core/app/config-tables-columns.php';
+        $destinationFile = $root . '/core/app_cruddiy_tests/config-tables-columns.php';
 
         // Copy the file
         if (!copy($sourceFile, $destinationFile)) {

--- a/tests/behat/features/public/create.feature
+++ b/tests/behat/features/public/create.feature
@@ -1,7 +1,7 @@
 Feature: Check public create page content
 
   Scenario: Add supplier
-    Given I am on "/core/app/suppliers-index.php"
+    Given I am on "/core/app_cruddiy_tests/suppliers-index.php"
     Then I should see "The Suppliers List"
     And I should see "No records were found."
 
@@ -35,7 +35,7 @@ Feature: Check public create page content
 
 
   Scenario: Add product
-    Given I am on "/core/app/products-index.php"
+    Given I am on "/core/app_cruddiy_tests/products-index.php"
     Then I should see "The Products List"
 
     When I follow "Add New Record"
@@ -59,7 +59,7 @@ Feature: Check public create page content
 
 
   Scenario: Add product with upload file
-    Given I am on "/core/app/products-create.php"
+    Given I am on "/core/app_cruddiy_tests/products-create.php"
 
     When I fill in "ean" with "2345678901234"
     And I fill in "product_name" with "Test Product Name 2 with file"

--- a/tests/behat/features/public/delete.feature
+++ b/tests/behat/features/public/delete.feature
@@ -1,7 +1,7 @@
 Feature: Check public delete page content
 
   Scenario: Check if there is a warning before deletion
-    Given I am on "/core/app/brands-index.php"
+    Given I am on "/core/app_cruddiy_tests/brands-index.php"
     And I follow "delete-3"
     # TODO: display record on the delete page
     # Then the response should contain "Under Armour"
@@ -10,7 +10,7 @@ Feature: Check public delete page content
     And I should see "Are you sure"
 
   Scenario: Delete a Suppliers record
-    Given I am on "/core/app/suppliers-index.php"
+    Given I am on "/core/app_cruddiy_tests/suppliers-index.php"
     And I follow "delete-2"
     And I should see "Delete Record"
     And I should see "Are you sure"
@@ -18,7 +18,7 @@ Feature: Check public delete page content
     Then I should see "1 results"
 
   Scenario: Check FK dependency
-    Given I am on "/core/app/suppliers-index.php"
+    Given I am on "/core/app_cruddiy_tests/suppliers-index.php"
     And I follow "delete-1"
     And I should see "Delete Record"
     And I should see "Are you sure"

--- a/tests/behat/features/public/index.feature
+++ b/tests/behat/features/public/index.feature
@@ -2,7 +2,7 @@
 Feature: Check public index page content
 
   Scenario: Check Brands list
-    Given I am on "/core/app/brands-index.php"
+    Given I am on "/core/app_cruddiy_tests/brands-index.php"
     Then I should not see "Parse error"
     And I should not see "Fatal error"
 
@@ -52,7 +52,7 @@ Feature: Check public index page content
 
 
   Scenario: Check Products list
-    Given I am on "/core/app/brands-index.php"
-    And I am on "/core/app/suppliers-index.php"
+    Given I am on "/core/app_cruddiy_tests/brands-index.php"
+    And I am on "/core/app_cruddiy_tests/suppliers-index.php"
     Then I should see "No records were found."
 

--- a/tests/behat/features/public/read.feature
+++ b/tests/behat/features/public/read.feature
@@ -1,12 +1,12 @@
 Feature: Check public read page content
 
   Scenario: Go to Brands item
-    Given I am on "/core/app/brands-index.php"
+    Given I am on "/core/app_cruddiy_tests/brands-index.php"
     And I follow "read-3"
     Then I should see "Under Armour"
     And I should see "Update Record"
 
-    Given I am on "/core/app/brands-index.php"
+    Given I am on "/core/app_cruddiy_tests/brands-index.php"
     And I follow "read-4"
     Then I should see "Gola"
     And I should see "Update Record"

--- a/tests/behat/features/public/update.feature
+++ b/tests/behat/features/public/update.feature
@@ -1,14 +1,14 @@
 Feature: Check public update page content
 
   Scenario: Go to Brands item
-    Given I am on "/core/app/brands-index.php"
+    Given I am on "/core/app_cruddiy_tests/brands-index.php"
     And I follow "update-3"
     Then the response should contain "Under Armour"
     And the response should not contain "Gola"
     And I should see "Please edit the input values and submit to update the record."
     And I should see "Update Record"
 
-    Given I am on "/core/app/brands-index.php"
+    Given I am on "/core/app_cruddiy_tests/brands-index.php"
     And I follow "update-4"
     Then the response should contain "Gola"
     And the response should not contain "Under Armour"
@@ -18,7 +18,7 @@ Feature: Check public update page content
 
 
   Scenario: Update a record
-    Given I am on "/core/app/brands-update.php?id=3"
+    Given I am on "/core/app_cruddiy_tests/brands-update.php?id=3"
     And I fill in "name" with "Under Armour updated"
     And I press "Edit"
 
@@ -30,7 +30,7 @@ Feature: Check public update page content
 
 
   Scenario: Update a record with a file upload
-    Given I am on "/core/app/products-update.php?id=2"
+    Given I am on "/core/app_cruddiy_tests/products-update.php?id=2"
     And I fill in "product_name" with "Test Product Name 2 with updated file"
     And I attach the file "./tests/assets/cruddiy_test_image.jpg" to "packshot_file"
     And I press "Edit"
@@ -45,7 +45,7 @@ Feature: Check public update page content
 
   # @javascript
   Scenario: Preserve existing attachment when updating a record without picking a new file
-    Given I am on "/core/app/products-update.php?id=2"
+    Given I am on "/core/app_cruddiy_tests/products-update.php?id=2"
     And I fill in "product_name" with "Test Product Name 2 with preserved file"
     And I press "Edit"
 
@@ -59,34 +59,34 @@ Feature: Check public update page content
 
 
   Scenario: Successfully updating a product file
-    Given I am on "/core/app/products-update.php?id=2"
+    Given I am on "/core/app_cruddiy_tests/products-update.php?id=2"
     When I attach the file "./tests/assets/cruddiy_test_image.jpg" to "packshot_file"
     And I press "Edit"
     Then I should see "cruddiy_test_image.jpg"
 
   Scenario: Attempting to upload a product file but leaving the file input empty
-    Given I am on "/core/app/products-update.php?id=2"
+    Given I am on "/core/app_cruddiy_tests/products-update.php?id=2"
     When I press "Edit"
     Then I should see "cruddiy_test_image.jpg"
 
   Scenario: Using a backup file for a product when no file is uploaded
-    Given I am on "/core/app/products-update.php?id=2"
+    Given I am on "/core/app_cruddiy_tests/products-update.php?id=2"
     When I attach the file "" to "packshot_file"
     And I press "Edit"
     Then I should see "cruddiy_test_image.jpg"
 
   Scenario: Deleting an uploaded product file
-    Given I am on "/core/app/products-update.php?id=2"
+    Given I am on "/core/app_cruddiy_tests/products-update.php?id=2"
     When I check "cruddiy_delete_packshot_file"
     And I press "Edit"
     Then I should not see "cruddiy_test_image.jpg"
 
   Scenario: Attempting to delete a product file that does not exist
-    Given I am on "/core/app/products-update.php?id=2"
+    Given I am on "/core/app_cruddiy_tests/products-update.php?id=2"
     Then I should not see a "cruddiy_backup_packshot_file" element
 
   Scenario: Successfully updating a new product file
-    Given I am on "/core/app/products-update.php?id=2"
+    Given I am on "/core/app_cruddiy_tests/products-update.php?id=2"
     When I attach the file "./tests/assets/cruddiy_test_image.jpg" to "packshot_file"
     And I press "Edit"
     Then I should see "cruddiy_test_image.jpg"

--- a/tests/coverage.md
+++ b/tests/coverage.md
@@ -17,8 +17,6 @@
   -   Scenario: Check for errors on Tables page
 - Feature: Check admin tables mapping form
   -   Scenario: Fill the tables form
-- Feature: Check admin columns page
-  -   Scenario: Check for errors on the Columns page
 - Feature: Check admin columns form
   -   Scenario: Name and select Brands columns
 - Feature: Check field default values
@@ -27,6 +25,9 @@
   -   Scenario: Set values
 - Feature: Check the generator execution
   -   Scenario: Verify errors and execution
+- Feature: Check .gitignore file
+  -   Scenario: Check confirmation message on generate
+  -   Scenario: Check for the existence of destination subdirectory in .gitignore
 - Feature: Check the generator result
   -   Scenario: Look for errors and data continuity
 - Feature: Check public index page content
@@ -53,8 +54,37 @@
   -   Scenario: Check if there is a warning before deletion
   -   Scenario: Delete a Suppliers record
   -   Scenario: Check FK dependency
-- Feature: Check admin index page content
+- Feature: Check admin index page content when regenerating CRUD
+  -   Scenario: Existing configuration was detected
+  -   Scenario: Restart configuration from scratch
+  -   Scenario: Re-using an existing configuration
+- Feature: The form should be pre-field
+  -   Scenario: Look for config file variables and uncheck gitignore
+- Feature: Check admin relations page content
   -   Scenario: No errors on page
+- Feature: Check admin relations creation form
+  -   Scenario: Check unicity display of existing relations
+- Feature: Check admin tables page
+  -   Scenario: Check for errors on Tables page
+- Feature: Check admin tables page
+  -   Scenario: Check for preconfiguration from config-tables-columns.php
+- Feature: Check admin tables mapping form
+  -   Scenario: Submit the form with preconfigured values
+- Feature: Check admin columns form
+  -   Scenario: Name and select Brands columns
+- Feature: Check field default values
+  -   Scenario: Name and select Brands columns when the generator has already run
+- Feature: Check the generator execution
+  -   Scenario: Verify errors and execution
+- Feature: Check .gitignore file
+  -   Scenario: Check confirmation message on generate
+  -   Scenario: Check for the existence of destination subdirectory in .gitignore
+- Feature: Check the generator result
+  -   Scenario: Look for errors and data continuity
+- Feature: Check admin index page content when regenerating CRUD
+  -   Scenario: Existing configuration was detected
+  -   Scenario: Restart configuration from scratch
+  -   Scenario: Re-using an existing configuration
 - Feature: The form should be pre-field
   -   Scenario: Look for config file variables
 - Feature: Check admin relations page content
@@ -67,14 +97,15 @@
   -   Scenario: Check for preconfiguration from config-tables-columns.php
 - Feature: Check admin tables mapping form
   -   Scenario: Submit the form with preconfigured values
-- Feature: Check admin columns page
-  -   Scenario: Check for errors on the Columns page
 - Feature: Check admin columns form
   -   Scenario: Name and select Brands columns
 - Feature: Check field default values
   -   Scenario: Name and select Brands columns when the generator has already run
 - Feature: Check the generator execution
   -   Scenario: Verify errors and execution
+- Feature: Check .gitignore file
+  -   Scenario: Check confirmation message on generate
+  -   Scenario: Check for the existence of destination subdirectory in .gitignore
 - Feature: Check the generator result
   -   Scenario: Look for errors and data continuity
 - Feature: Check public index page content


### PR DESCRIPTION
# This PR lets you set a custom folder for generated CRUD pages!

![](https://files.italic.fr/firefox_zOr3eFvQwt.png)

![](https://files.italic.fr/Code_BC4ns3R7iO.png)

---


## Custom directory
- Simply type the relative destination folder name (#30)
- Automatic sanitizing of the folder name (special characters)
- Blacklist for reserved folder names
- One can decide to add the CRUD files to .gitignore or not
- Users can restart more easily after CRUD generations
- Cruddiy can reload the config files from any core/subdirectory
- But it can also generate the CRUD outside core (no reloading, thought)

![](https://files.italic.fr/firefox_slclF7vbTj.png)

> **Warning:** depending on your web server configuration (Directory Index), if you generate outsite the project root directory or the core folder, your CRUD pages may not be accessible in the browser.


---

## Blacklist for reserved folder names

Users are not allowed to name their folder after existing directories such as "core", "locales", "tests"

![](https://files.italic.fr/firefox_sbkOcfeI2i.png)
---

## Config reloading

Since PR #73 Cruddiy remembers the config from the previous run of the generator.

However, what happens when there runs in different directories?

If you generated into `core/`, Cruddiy will parse subfolders and let you decide which config you want to reload:

![](https://files.italic.fr/firefox_ZLZZHNfaQF.gif)

This works from any page: core/index.php, core/tables.php, core/columns.php...

We could eventually let users select a directory outside core if there is demand for that.

---

## Restart after generation

It's easier now:

![](https://files.italic.fr/firefox_NGj70R83Df.png)

You can even restart from scratch if you don't want to re-use any previous run.

---

## Also in this PR

- 7f2e421 • Error messages when database, username, password are empty

![](https://files.italic.fr/chrome_TC4tJk3UR7.png)

- Explicitely stating the default value for pagination

![](https://files.italic.fr/chrome_NqUKqXpDnR.png)

- e7194f7 • Updated tests for the generator
- 1c46986 • Updated tests for the generated CRUD pages
- 6fe65f6 • Updated code coverage
- 5e0db3b • Bugfix: APP_NAME was not replaced if only one table is selected
- 6fb8477 • Bootstrap 4 "muted" text style for hints

---

Please comment or open tickets if you spot any bug.

Happy CRUDing!