### PR TITLE
Feature/export

### DIFF
--- a/core/generate.php
+++ b/core/generate.php
@@ -1196,6 +1196,9 @@ function extractTableAndColumnsNames($postdata) {
                 $tables_and_columns_names[extractTableName($table)]['columns'][$column['columnname']]['is_file'] = isset($column['file']) && $column['file'] ? 1 : 0;
                 $tables_and_columns_names[extractTableName($table)]['columns'][$column['columnname']]['columnvisible'] = isset($column['columnvisible']) && $column['columnvisible'] ? 1 : 0;
                 $tables_and_columns_names[extractTableName($table)]['columns'][$column['columnname']]['columninpreview'] = isset($column['columninpreview']) && $column['columninpreview'] ? 1 : 0;
+                $tables_and_columns_names[extractTableName($table)]['columns'][$column['columnname']]['fk'] = isset($column['fk']) && $column['fk'] ? 1 : 0;
+                $tables_and_columns_names[extractTableName($table)]['columns'][$column['columnname']]['primary'] = isset($column['primary']) && $column['primary'] ? 1 : 0;
+                $tables_and_columns_names[extractTableName($table)]['columns'][$column['columnname']]['auto'] = isset($column['auto']) && $column['auto'] ? 1 : 0;
             }
         }
     }

--- a/core/generate.php
+++ b/core/generate.php
@@ -1006,7 +1006,7 @@ function generate($postdata) {
                     if (!$forced_deletion && (!isset($_POST['keep_startpage']) || (isset($_POST['keep_startpage']) && $_POST['keep_startpage'] != 'true'))) {
                         $forced_deletion = true;
                         echo '<h3>Deleting existing files in '. $_SESSION['destination'] .'/</h3>';
-                        $keep = array('config.php', 'helpers.php', 'config-tables-columns.php', 'locales');
+                        $keep = array('config.php', 'config-tables-columns.php', 'locales');
                         foreach (glob($_SESSION['destination'] . "/*") as $file) {
                             if (!in_array(basename($file), $keep)) {
                                 if (is_file($file)) {
@@ -1016,6 +1016,23 @@ function generate($postdata) {
                                 }
                             }
                         }
+
+                        echo '<br>';
+
+                        echo '<h3>Helpers file</h3>';
+
+                        // Regenerate helpers file
+                        $helpersfilename = 'helpers.php';
+                        $handle = fopen('helpers.php', "r") or die("Unable to open Helpers file! Please check your file permissions.");;
+                        $helpers = fread($handle, filesize($helpersfilename));
+                        fclose($handle);
+
+                        $helpersfile = fopen($_SESSION['destination'] . '/'. $helpersfilename, "w") or die("Unable to create Helpers file! Please check your file permissions");
+                        fwrite($helpersfile, $helpers);
+                        fclose($helpersfile);
+
+                        echo "Updated.<br>";
+
 
                         echo '<br>';
                         global $upload_target_dir;

--- a/core/helpers.php
+++ b/core/helpers.php
@@ -334,111 +334,253 @@ function getConfigDirectories($baseDir, $excludedDirs = ['locales', 'templates']
 
 
 
-// Export raw table as CSV
-function exportRawTableAsCSV($link, $tables_and_columns_names, $tableName, $debug = false) {
-    $filename = $tableName . "_export_" . date('Ymd') . ".csv";
+function exportAsCSV($data, $db_name, $tables_and_columns_names, $table_name, $link, $debug = false) {
 
+    // Find relations in table
+    $relations = get_foreign_key_relations($link, $db_name);
+
+    // Generate headers
+    $headers = extract_csv_headers($relations, $tables_and_columns_names, $table_name, $debug);
+
+    // Generate rows
+    $lines = [];
+    foreach($data as $row) {
+        $lines[] = extract_csv_data($row, $relations, $db_name, $tables_and_columns_names, $table_name, $link, $debug);
+    }
+
+    if ($debug) {
+        echo "<pre>";
+        print_r($headers);
+        print_r($lines);
+        echo "</pre>";
+    }
+
+    // Assemble the CSV
+    create_csv($headers, $lines, $table_name, $debug);
+}
+
+
+
+function create_csv($headers, $lines, $table_name, $debug = false) {
+
+    // Set appropriate headers for output
     if (!$debug) {
         header('Content-Type: text/csv');
-        header('Content-Disposition: attachment; filename="'.$filename.'"');
-    } else {
-        header('Content-Type: text/plain'); // Display in browser as plain text
+        header('Content-Disposition: attachment; filename="' . $table_name . '_export.csv"');
     }
 
+    // Open output stream for writing
     $output = fopen($debug ? 'php://output' : 'php://temp', 'w+');
 
-    // Check if the table configuration exists
-    if (!isset($tables_and_columns_names[$tableName])) {
-        die("Table configuration for '$tableName' not found.");
-    }
-
-    // Extract headers and column names
-    $headers = [];
-    $columnNames = [];
-    foreach ($tables_and_columns_names[$tableName]['columns'] as $key => $value) {
-        if (isset($value['columndisplay']) && $value['columnvisible']) {
-            $headers[] = $value['columndisplay'];
-            $columnNames[] = $key;
-        }
-    }
-
-    // Add CSV headers
-    fputcsv($output, $headers);
-
-    // Build the query
-    $columnsString = implode(", ", $columnNames);
-    $query = "SELECT $columnsString FROM `$tableName`";
-    $result = mysqli_query($link, $query);
-
-    if (!$result) {
-        die("ERROR: Could not execute query: $query. " . mysqli_error($link));
-    }
-
-    // Output each row as a line in the CSV
-    while ($row = mysqli_fetch_assoc($result)) {
-        $formattedRow = array_intersect_key($row, array_flip($columnNames));
-        fputcsv($output, $formattedRow);
-    }
-
-    if ($debug) {
-        fclose($output);
-    } else {
-        rewind($output);
-        fpassthru($output);
-        fclose($output);
-    }
-    exit;
-}
-
-
-
-function exportAsCSV($data, $tables_and_columns_names, $tableName, $debug = false) {
-    // Define headers based on configuration
-    $headers = [];
-    foreach ($tables_and_columns_names[$tableName]['columns'] as $column => $config) {
-        if ($config['columnvisible']) {
-            $headers[] = $config['columndisplay'];
-        }
-    }
-
-    // Handle headers for related tables if necessary
-    // ...
-
-    // Set the appropriate headers for debug mode or CSV download
-    if ($debug) {
-        header('Content-Type: text/plain');  // Display in browser as plain text
-    } else {
-        header('Content-Type: text/csv');
-        header('Content-Disposition: attachment; filename="' . $tableName . '_export.csv"');
-    }
-
-    // Open output stream
-    $output = fopen($debug ? 'php://output' : 'php://temp', 'w+');
-
-    // Write the headers to CSV
-    fputcsv($output, $headers);
+    // Write CSV headers
+    fputcsv($output, array_values($headers));
 
     // Iterate through the data and write to CSV
-    foreach ($data as $row) {
-        $formattedRow = [];
-        foreach ($tables_and_columns_names[$tableName]['columns'] as $column => $config) {
-            if ($config['columnvisible']) {
-                $formattedRow[] = $row[$column] ?? '';
-            }
-        }
-        fputcsv($output, $formattedRow);
+    foreach($lines as $line) {
+        fputcsv($output, $line);
     }
 
-    // Finalize the CSV output
-    if ($debug) {
-        fclose($output);
-    } else {
+    // Finalize CSV output for download
+    if (!$debug) {
         rewind($output);
         fpassthru($output);
         fclose($output);
     }
-    exit;
 }
 
-// Usage example:
-// exportAsCSV($data, $tables_and_columns_names, 'products', true); // For debug mode
+
+
+function extract_csv_data($row, $relations, $db_name, $tables_and_columns_names, $table_name, $link, $debug = false) {
+    // Init headers
+    $line = [];
+
+    // Parse config-tables-columns.php to get the table display settings
+    foreach ($tables_and_columns_names[$table_name]['columns'] as $column_name => $column_config) {
+        // Add column if it's visible
+        if ($column_config['columnvisible']) {
+
+            // The column value in this row
+            $value = $row[$column_name];
+
+            // Check if the column is a foreign key
+            $relation = find_relation_by_column($relations, $column_name);
+
+            // The column is a FK
+            if ($relation !== NULL) {
+                if ($debug) {
+                    // Name of the column that is a foreign key
+                    echo "<br>FK <strong>".$relation['table'].'.'.$relation['column']. '</strong> : '.$tables_and_columns_names[$relation['table']]['columns'][$relation['column']]['columndisplay'];
+                }
+
+                $primary = find_primary_key_from_config($table_name, $tables_and_columns_names);
+
+                if ($debug) {
+                    echo "<br>&nbsp;value: " . $value;
+                }
+
+                if ($value !== null) {
+                    // Get data from related table
+                    $related_value = get_related_table_data($link, $relation['table'], $primary, $value, $debug);
+                } else {
+                    // Keep the null value for the CSV row
+                    $related_value = null;
+                }
+
+                // Look for the columns in the foreign table that are displayed in the preview
+                foreach($tables_and_columns_names[$relation['table']]['columns'] as $related_column => $related_column_config) {
+                    if ($related_column_config['columninpreview']) {
+
+                        if ($related_column_config['columninpreview']) {
+
+                            if ($debug) {
+                                if ($value !== null) {
+                                    echo "<br>&nbsp;related value: " . $related_value[$related_column];
+                                } else {
+                                    echo "<br>&nbsp;related value: <code>null</code>";
+                                }
+                            }
+
+                            if ($value !== null) {
+                                $line[] = $related_value[$related_column];
+                            } else {
+                                $line[] = null;
+                            }
+                        }
+                    }
+                }
+
+            }
+            // The column is not a FK
+            else {
+                if ($debug) {
+                    echo "<br>column <code>$column_name</code> (".$value.')';
+                }
+                $line[] = $value;
+            }
+        }
+    }
+
+    if ($debug) {
+        echo "<hr>";
+    }
+
+    return $line;
+}
+
+
+
+function get_related_table_data($link, $referenced_table_name, $primary, $value, $debug = false) {
+
+    $sql = "
+        SELECT *
+        FROM   `$referenced_table_name`
+        WHERE  `$referenced_table_name`.`$primary` = $value
+    ";
+
+    if ($debug) {
+        echo '<pre>';
+        print_r($sql);
+        echo '</pre>';
+    }
+
+    $result = mysqli_query($link, $sql);
+    $row = mysqli_fetch_assoc($result);
+    return $row;
+}
+
+
+
+function extract_csv_headers($relations, $tables_and_columns_names, $table_name, $debug = false) {
+    // Init headers
+    $headers = [];
+
+    // Parse config-tables-columns.php to get the table display settings
+    foreach ($tables_and_columns_names[$table_name]['columns'] as $column => $column_config) {
+        // Add column if it's visible
+        if ($column_config['columnvisible']) {
+
+            // Check if the column is a foreign key
+            $relation = find_relation_by_column($relations, $column);
+
+            // The column is a FK
+            if ($relation !== NULL) {
+                if ($debug) {
+                    // Name of the column that is a foreign key
+                    echo "<br>FK <strong>".$relation['table'].'.'.$relation['column']. '</strong> : '.$tables_and_columns_names[$relation['table']]['columns'][$relation['column']]['columndisplay'];
+                }
+
+                // Look for the columns in the foreign table that are displayed in the preview
+                foreach($tables_and_columns_names[$relation['table']]['columns'] as $related_column => $related_column_config) {
+                    if ($related_column_config['columninpreview']) {
+
+                        if ($related_column_config['columninpreview']) {
+
+                            if ($column_config['columndisplay'] == $related_column_config['columndisplay']) {
+                                $title = $related_column_config['columndisplay'];
+                            } else {
+                                $title = $column_config['columndisplay'] . ' - ' . $related_column_config['columndisplay'];
+                            }
+
+                            if ($debug) {
+                                echo "<br>&nbsp;related <code>".$related_column. '</code> ('.$title.')';
+                            }
+                            $headers[] =  $title;
+                        }
+                    }
+                }
+            }
+            // The column is not a FK
+            else {
+                if ($debug) {
+                    echo "<br>column <code>$column</code> (".$column_config['columndisplay'].')';
+                }
+                $headers[] = $column_config['columndisplay'];
+            }
+        }
+    }
+    return $headers;
+}
+
+
+
+function get_foreign_key_relations($link, $db_name) {
+    $sql = "
+        SELECT
+            TABLE_NAME,
+            COLUMN_NAME,
+            CONSTRAINT_NAME,
+            REFERENCED_TABLE_NAME,
+            REFERENCED_COLUMN_NAME
+        FROM
+            INFORMATION_SCHEMA.KEY_COLUMN_USAGE
+        WHERE
+            REFERENCED_TABLE_SCHEMA = '$db_name'
+    ";
+    $result = mysqli_query($link, $sql);
+    $rows = mysqli_fetch_all($result, MYSQLI_ASSOC);
+    return $rows;
+}
+
+
+
+function find_relation_by_column($relations, $column_name) {
+    foreach ($relations as $relation) {
+        if ($relation['COLUMN_NAME'] === $column_name) {
+            return [
+                'table' => $relation['REFERENCED_TABLE_NAME'],
+                'column' => $relation['REFERENCED_COLUMN_NAME'],
+            ];
+        }
+    }
+    return NULL;
+}
+
+
+
+function find_primary_key_from_config($table_name, $tables_and_columns_names) {
+    foreach ($tables_and_columns_names[$table_name]['columns'] as $column_name => $column_config) {
+        if ($column_config['primary']) {
+            return $column_name;
+        }
+    }
+}

--- a/core/helpers.php
+++ b/core/helpers.php
@@ -335,22 +335,40 @@ function getConfigDirectories($baseDir, $excludedDirs = ['locales', 'templates']
 
 
 // Export data as CSV
-function exportAsCSV($data) {
-    header('Content-Type: text/csv');
-    header('Content-Disposition: attachment; filename="export.csv"');
-
-    $output = fopen('php://output', 'w');
-
-    // Add CSV headers (column names)
-    if (!empty($data)) {
-        fputcsv($output, array_keys(reset($data)));
+function exportAsCSV($data, $tables_and_columns_names, $table_name = '', $debug = false) {
+    if (!$debug) {
+        // CSV headers
+        header('Content-Type: text/csv');
+        header('Content-Disposition: attachment; filename="export-'.$table_name.'.csv"');
+    } else {
+        // Display in browser as plain text
+        header('Content-Type: text/plain');
     }
+
+    $output = fopen($debug ? 'php://output' : 'php://temp', 'w+');
+
+    // Extract headers from configuration
+    $headers = [];
+    foreach ($tables_and_columns_names['products']['columns'] as $key => $value) {
+        if (isset($value['columndisplay']) && $value['columnvisible']) {
+            $headers[$key] = $value['columndisplay'];
+        }
+    }
+
+    // Add CSV headers
+    fputcsv($output, $headers);
 
     // Output data
     foreach ($data as $row) {
         fputcsv($output, $row);
     }
 
-    fclose($output);
+    if ($debug) {
+        fclose($output);
+    } else {
+        rewind($output);
+        fpassthru($output);
+        fclose($output);
+    }
     exit;
 }

--- a/core/helpers.php
+++ b/core/helpers.php
@@ -316,7 +316,7 @@ function findConfigFile() {
 
 
 
-// Function to scan directories and find config.php
+// Scan directories and find config.php
 function getConfigDirectories($baseDir, $excludedDirs = ['locales', 'templates']) {
     $dirs = array_filter(glob($baseDir . '/*', GLOB_ONLYDIR), function ($dir) use ($excludedDirs) {
         return !in_array(basename($dir), $excludedDirs);
@@ -330,4 +330,27 @@ function getConfigDirectories($baseDir, $excludedDirs = ['locales', 'templates']
     }
 
     return $configDirs;
+}
+
+
+
+// Export data as CSV
+function exportAsCSV($data) {
+    header('Content-Type: text/csv');
+    header('Content-Disposition: attachment; filename="export.csv"');
+
+    $output = fopen('php://output', 'w');
+
+    // Add CSV headers (column names)
+    if (!empty($data)) {
+        fputcsv($output, array_keys(reset($data)));
+    }
+
+    // Output data
+    foreach ($data as $row) {
+        fputcsv($output, $row);
+    }
+
+    fclose($output);
+    exit;
 }

--- a/core/index.php
+++ b/core/index.php
@@ -44,6 +44,11 @@ if (isset($_GET['generator']) && $_GET['generator'] == 'new') {
                 <?php foreach($configDirectories as $dir) : ?>
                     <a href="<?php echo htmlspecialchars($dir); ?>" target="_blank" rel="noopener noreferrer" class="btn btn-primary my-2 mx-2"><?php echo htmlspecialchars($dir); ?> &nbsp; <i class="fa fa-external-link" aria-hidden="true"></i></a>
                 <?php endforeach ?>
+
+                <p>
+                    <br>
+                    <a href="directory.php" class="btn btn-secondary btn-sm">Restart generating an app</a>
+                </p>
             </div>
             <hr>
         <?php endif ?>

--- a/core/index.php
+++ b/core/index.php
@@ -55,6 +55,7 @@ if (isset($_GET['generator']) && $_GET['generator'] == 'new') {
 
             <!-- Form Name -->
             <div class="text-center pt-5">
+                <?php // TODO:change title to "Edit app" when re-using a configuration  ?>
                 <h4>Generate a new app</h4>
                 <h6>Enter database information:</h6>
             </div>

--- a/core/locales/cn.php
+++ b/core/locales/cn.php
@@ -12,6 +12,7 @@ return array(
     '%s Details' => '%s详情',
     'Actions' => '操作',
     'No records were found.' => '未找到记录。',
+    'Export as CSV' => '导出为CSV',
 
     // update records
     'Update Record' => '更新记录',

--- a/core/locales/cn.php
+++ b/core/locales/cn.php
@@ -1,59 +1,59 @@
 <?php
 return array(
     // menus
-    'Select Page' => '选择页面',
-    'Back' => '返回',
-    'Back to List' => '返回列表',
+    'Select Page'                  => '选择页面',
+    'Back'                         => '返回',
+    'Back to List'                 => '返回列表',
 
     // list records
-    'View' => '查看',
-    'Reset View' => '重置查看',
-    'View Record' => '查看记录',
-    '%s Details' => '%s详情',
-    'Actions' => '操作',
-    'No records were found.' => '未找到记录。',
-    'Export as CSV' => '导出为CSV',
+    'View'                         => '查看',
+    'Reset View'                   => '重置查看',
+    'View Record'                  => '查看记录',
+    '%s Details'                   => '%s详情',
+    'Actions'                      => '操作',
+    'No records were found.'       => '未找到记录。',
+    'Export as CSV'                => '导出为CSV',
 
     // update records
-    'Update Record' => '更新记录',
-    'update_record_instructions' => '请编辑输入值并提交以更新记录。',
+    'Update Record'                => '更新记录',
+    'update_record_instructions'   => '请编辑输入值并提交以更新记录。',
 
     // delete records
-    'Delete' => '删除',
-    'Delete File' => '删除%s',
-    'Delete Record' => '删除记录',
-    'delete_record_confirm' => '您确定要删除此记录吗？',
+    'Delete'                       => '删除',
+    'Delete File'                  => '删除%s',
+    'Delete Record'                => '删除记录',
+    'delete_record_confirm'        => '您确定要删除此记录吗？',
 
     // add records
-    'Add New Record' => '添加新记录',
-    'add_new_record_instructions' => '请填写此表格并提交以将记录添加到数据库。',
-    'Create' => '创建',
-    'required_fiels_instructions' => '* 字段不能为空',
+    'Add New Record'               => '添加新记录',
+    'add_new_record_instructions'  => '请填写此表格并提交以将记录添加到数据库。',
+    'Create'                       => '创建',
+    'required_fiels_instructions'  => '* 字段不能为空',
 
     // search & paging
-    'Search this table' => '搜索此表',
-    'First' => '首页',
-    'Last' => '尾页',
-    'total_results' => '%s个结果 - 第%s页，共%s页',
-    'Prev' => '上一页',
-    'Next' => '下一页',
+    'Search this table'            => '搜索此表',
+    'First'                        => '首页',
+    'Last'                         => '尾页',
+    'total_results'                => '%s个结果 - 第%s页，共%s页',
+    'Prev'                         => '上一页',
+    'Next'                         => '下一页',
 
     // buttons
-    'Yes' => '是',
-    'No' => '否',
-    'Cancel' => '取消',
+    'Yes'                          => '是',
+    'No'                           => '否',
+    'Cancel'                       => '取消',
 
     // errors
-    'Error' => "错误",
-    'Invalid Request' => "无效请求",
-    'stmt_error' => '哎呀！出了点问题。请稍后再试。',
-    'unsupported_no_pk' => "目前还不支持编辑没有主键的表。",
+    'Error'                        => "错误",
+    'Invalid Request'              => "无效请求",
+    'stmt_error'                   => '哎呀！出了点问题。请稍后再试。',
+    'unsupported_no_pk'            => "目前还不支持编辑没有主键的表。",
     'invalid_request_instructions' => "对不起，您的请求无效。请<a href='index.php' class='alert-link'>返回</a>重试。",
 
 
     // foreign keys
-    "references_tables" => "对此 %s 的引用:",
-    "references_view_btn" => "查看 %s %s 与 %s = %s",
+    "references_tables"            => "对此 %s 的引用:",
+    "references_view_btn"          => "查看 %s %s 与 %s = %s",
 
 
 );

--- a/core/locales/cz.php
+++ b/core/locales/cz.php
@@ -12,6 +12,7 @@ return array(
     '%s Details' => 'Detaily %s',
     'Actions' => 'Akce',
     'No records were found.' => 'Nebyly nalezeny žádné záznamy.',
+    'Export as CSV' => 'Exportovat jako CSV',
 
     // update records
     'Update Record' => 'Aktualizovat záznam',

--- a/core/locales/cz.php
+++ b/core/locales/cz.php
@@ -1,58 +1,58 @@
 <?php
 return array(
     // menus
-    'Select Page' => 'Vyberte stránku',
-    'Back' => 'Zpět',
-    'Back to List' => 'Zpět na seznam',
+    'Select Page'                  => 'Vyberte stránku',
+    'Back'                         => 'Zpět',
+    'Back to List'                 => 'Zpět na seznam',
 
     // list records
-    'View' => 'Zobrazit',
-    'Reset View' => 'Resetovat zobrazení',
-    'View Record' => 'Zobrazit záznam',
-    '%s Details' => 'Detaily %s',
-    'Actions' => 'Akce',
-    'No records were found.' => 'Nebyly nalezeny žádné záznamy.',
-    'Export as CSV' => 'Exportovat jako CSV',
+    'View'                         => 'Zobrazit',
+    'Reset View'                   => 'Resetovat zobrazení',
+    'View Record'                  => 'Zobrazit záznam',
+    '%s Details'                   => 'Detaily %s',
+    'Actions'                      => 'Akce',
+    'No records were found.'       => 'Nebyly nalezeny žádné záznamy.',
+    'Export as CSV'                => 'Exportovat jako CSV',
 
     // update records
-    'Update Record' => 'Aktualizovat záznam',
-    'update_record_instructions' => 'Upravte hodnoty a odešlete k aktualizaci záznamu.',
+    'Update Record'                => 'Aktualizovat záznam',
+    'update_record_instructions'   => 'Upravte hodnoty a odešlete k aktualizaci záznamu.',
 
     // delete records
-    'Delete' => 'Smazat',
-    'Delete File' => 'Smazat %s',
-    'Delete Record' => 'Smazat záznam',
-    'delete_record_confirm' => 'Jste si jisti, že chcete tento záznam smazat?',
+    'Delete'                       => 'Smazat',
+    'Delete File'                  => 'Smazat %s',
+    'Delete Record'                => 'Smazat záznam',
+    'delete_record_confirm'        => 'Jste si jisti, že chcete tento záznam smazat?',
 
     // add records
-    'Add New Record' => 'Přidat nový záznam',
-    'add_new_record_instructions' => 'Vyplňte tento formulář a odešlete, abyste přidali záznam do databáze.',
-    'Create' => 'Vytvořit',
-    'required_fiels_instructions' => '* pole nesmí být prázdné',
+    'Add New Record'               => 'Přidat nový záznam',
+    'add_new_record_instructions'  => 'Vyplňte tento formulář a odešlete, abyste přidali záznam do databáze.',
+    'Create'                       => 'Vytvořit',
+    'required_fiels_instructions'  => '* pole nesmí být prázdné',
 
     // search & paging
-    'Search this table' => 'Vyhledávat v této tabulce',
-    'First' => 'První',
-    'Last' => 'Poslední',
-    'total_results' => '%s výsledků - Strana %s z %s',
-    'Prev' => 'Předchozí',
-    'Next' => 'Další',
+    'Search this table'            => 'Vyhledávat v této tabulce',
+    'First'                        => 'První',
+    'Last'                         => 'Poslední',
+    'total_results'                => '%s výsledků - Strana %s z %s',
+    'Prev'                         => 'Předchozí',
+    'Next'                         => 'Další',
 
     // buttons
-    'Yes' => 'Ano',
-    'No' => 'Ne',
-    'Cancel' => 'Zrušit',
+    'Yes'                          => 'Ano',
+    'No'                           => 'Ne',
+    'Cancel'                       => 'Zrušit',
 
     // errors
-    'Error' => 'Chyba',
-    'Invalid Request' => 'Neplatný požadavek',
-    'stmt_error' => 'Jejda! Něco se pokazilo. Zkuste to prosím znovu později.',
-    'unsupported_no_pk' => 'Úprava tabulek bez primárního klíče zatím není podporována.',
+    'Error'                        => 'Chyba',
+    'Invalid Request'              => 'Neplatný požadavek',
+    'stmt_error'                   => 'Jejda! Něco se pokazilo. Zkuste to prosím znovu později.',
+    'unsupported_no_pk'            => 'Úprava tabulek bez primárního klíče zatím není podporována.',
     'invalid_request_instructions' => 'Omlouváme se, provedli jste neplatný požadavek. Prosím <a href="index.php" class="alert-link">vraťte se zpět</a> a zkuste to znovu.',
 
     // foreign keys
-    "references_tables" => "Odkazy na toto %s:",
-    "references_view_btn" => "Zobrazit %s %s s %s = %s",
+    "references_tables"            => "Odkazy na toto %s:",
+    "references_view_btn"          => "Zobrazit %s %s s %s = %s",
 
 
 );

--- a/core/locales/de.php
+++ b/core/locales/de.php
@@ -12,6 +12,7 @@ return array(
     '%s Details'                   => '%s Details',
     'Actions'                      => 'Aktionen',
     'No records were found.'       => 'Keine Datensätze gefunden.',
+    'Export as CSV' => 'Als CSV exportieren',
 
     // update records
     'Update Record'                => 'Datensatz aktualisieren',

--- a/core/locales/de.php
+++ b/core/locales/de.php
@@ -12,15 +12,15 @@ return array(
     '%s Details'                   => '%s Details',
     'Actions'                      => 'Aktionen',
     'No records were found.'       => 'Keine Datensätze gefunden.',
-    'Export as CSV' => 'Als CSV exportieren',
+    'Export as CSV'                => 'Als CSV exportieren',
 
     // update records
     'Update Record'                => 'Datensatz aktualisieren',
     'update_record_instructions'   => 'Bearbeiten Sie die Werte und senden Sie sie, um den Datensatz zu aktualisieren.',
 
     // delete records
-    'Delete' => 'Löschen',
-    'Delete File' => '%s löschen',
+    'Delete'                       => 'Löschen',
+    'Delete File'                  => '%s löschen',
     'Delete Record'                => 'Datensatz löschen',
     'delete_record_confirm'        => 'Sind Sie sicher, dass Sie diesen Datensatz löschen möchten?',
 
@@ -34,9 +34,9 @@ return array(
     'Search this table'            => 'Diese Tabelle durchsuchen',
     'First'                        => 'Erste',
     'Last'                         => 'Letzte',
-    'total_results' => '%s Ergebnisse - Seite %s von %s',
-    'Prev' => 'Vorherige',
-    'Next' => 'Nächste',
+    'total_results'                => '%s Ergebnisse - Seite %s von %s',
+    'Prev'                         => 'Vorherige',
+    'Next'                         => 'Nächste',
 
     // buttons
     'Yes'                          => 'Ja',
@@ -51,7 +51,7 @@ return array(
     'invalid_request_instructions' => 'Entschuldigung, Sie haben eine ungültige Anfrage gestellt. Bitte <a href="index.php" class="alert-link">gehen Sie zurück</a> und versuchen Sie es erneut.',
 
     // foreign keys
-    "references_tables" => "Verweise auf dieses %s:",
-    "references_view_btn" => "Zeige %s %s mit %s = %s",
+    "references_tables"            => "Verweise auf dieses %s:",
+    "references_view_btn"          => "Zeige %s %s mit %s = %s",
 
 );

--- a/core/locales/en.php
+++ b/core/locales/en.php
@@ -12,6 +12,7 @@ return array(
     '%s Details' => '%s List',
     'Actions' => "Actions",
     'No records were found.' => "No records were found.",
+    'Export as CSV' => 'Export as CSV',
 
     // update records
     'Update Record' => 'Update Record',

--- a/core/locales/en.php
+++ b/core/locales/en.php
@@ -1,59 +1,59 @@
 <?php
 return array(
     // menus
-    'Select Page' => 'Select content type',
-    'Back' => 'Back',
-    'Back to List' => "Back to List",
+    'Select Page'                  => 'Select content type',
+    'Back'                         => 'Back',
+    'Back to List'                 => "Back to List",
 
     // list records
-    'View' => 'View',
-    'Reset View' => 'Reset View',
-    'View Record' => 'View Record',
-    '%s Details' => '%s List',
-    'Actions' => "Actions",
-    'No records were found.' => "No records were found.",
-    'Export as CSV' => 'Export as CSV',
+    'View'                         => 'View',
+    'Reset View'                   => 'Reset View',
+    'View Record'                  => 'View Record',
+    '%s Details'                   => '%s List',
+    'Actions'                      => "Actions",
+    'No records were found.'       => "No records were found.",
+    'Export as CSV'                => 'Export as CSV',
 
     // update records
-    'Update Record' => 'Update Record',
-    'update_record_instructions' => 'Please edit the input values and submit to update the record.',
-    'Edit' => 'Edit',
+    'Update Record'                => 'Update Record',
+    'update_record_instructions'   => 'Please edit the input values and submit to update the record.',
+    'Edit'                         => 'Edit',
 
     // delete records
-    'Delete' => 'Delete',
-    'Delete File' => "Delete %s",
-    'Delete Record' => 'Delete Record',
-    'delete_record_confirm' => "Are you sure you want to delete this record?",
+    'Delete'                       => 'Delete',
+    'Delete File'                  => "Delete %s",
+    'Delete Record'                => 'Delete Record',
+    'delete_record_confirm'        => "Are you sure you want to delete this record?",
 
     // add records
-    'Add New Record' => 'Add New Record',
-    'add_new_record_instructions' => 'Please fill this form and submit to add a record to the database.',
-    'Create' => 'Create',
-    'required_fiels_instructions' => '* field can not be left empty',
+    'Add New Record'               => 'Add New Record',
+    'add_new_record_instructions'  => 'Please fill this form and submit to add a record to the database.',
+    'Create'                       => 'Create',
+    'required_fiels_instructions'  => '* field can not be left empty',
 
 
     // search & paging
-    'Search this table' => "Search this table",
-    'First' => "First",
-    'Last' => "Last",
-    'total_results' => "%s results - Page %s of %s",
-    'Prev' => 'Prev',
-    'Next' => 'Next',
+    'Search this table'            => "Search this table",
+    'First'                        => "First",
+    'Last'                         => "Last",
+    'total_results'                => "%s results - Page %s of %s",
+    'Prev'                         => 'Prev',
+    'Next'                         => 'Next',
 
     // buttons
-    'Yes' => "Yes",
-    'No' => "No",
-    'Cancel' => "Cancel",
+    'Yes'                          => "Yes",
+    'No'                           => "No",
+    'Cancel'                       => "Cancel",
 
     // errors
-    'Error' => "Error",
-    'Invalid Request' => "Invalid Request",
-    'stmt_error' => 'Oops! Something went wrong. Please try again later.',
-    'unsupported_no_pk' => "Editing tables without primary key isn't supported yet.",
+    'Error'                        => "Error",
+    'Invalid Request'              => "Invalid Request",
+    'stmt_error'                   => 'Oops! Something went wrong. Please try again later.',
+    'unsupported_no_pk'            => "Editing tables without primary key isn't supported yet.",
     'invalid_request_instructions' => "Sorry, you've made an invalid request. Please <a href='index.php' class='alert-link'>go back</a> and try again.",
 
     // foreign keys
-    "references_tables" => "References to this %s:",
-    "references_view_btn" => "View %s %s with %s = %s",
+    "references_tables"            => "References to this %s:",
+    "references_view_btn"          => "View %s %s with %s = %s",
 );
 ?>

--- a/core/locales/es.php
+++ b/core/locales/es.php
@@ -12,15 +12,15 @@ return array(
     '%s Details'                   => 'Detalles de %s',
     'Actions'                      => 'Acciones',
     'No records were found.'       => 'No se encontraron registros.',
-    'Export as CSV' => 'Exportar como CSV',
+    'Export as CSV'                => 'Exportar como CSV',
 
     // update records
     'Update Record'                => 'Actualizar registro',
     'update_record_instructions'   => 'Edite los valores y envíe para actualizar el registro.',
 
     // delete records
-    'Delete' => 'Eliminar',
-    'Delete File' => 'Eliminar %s',
+    'Delete'                       => 'Eliminar',
+    'Delete File'                  => 'Eliminar %s',
     'Delete Record'                => 'Eliminar registro',
     'delete_record_confirm'        => '¿Está seguro de que desea eliminar este registro?',
 
@@ -34,9 +34,9 @@ return array(
     'Search this table'            => 'Buscar en esta tabla',
     'First'                        => 'Primero',
     'Last'                         => 'Último',
-    'total_results' => '%s resultados - Página %s de %s',
-    'Prev' => 'Anterior',
-    'Next' => 'Siguiente',
+    'total_results'                => '%s resultados - Página %s de %s',
+    'Prev'                         => 'Anterior',
+    'Next'                         => 'Siguiente',
 
     // buttons
     'Yes'                          => 'Sí',
@@ -51,8 +51,8 @@ return array(
     'invalid_request_instructions' => 'Lo siento, ha realizado una solicitud inválida. Por favor, <a href="index.php" class="alert-link">regrese</a> e intente nuevamente.',
 
     // foreign keys
-    "references_tables" => "Referencias a este %s:",
-    "references_view_btn" => "Ver %s %s con %s = %s",
+    "references_tables"            => "Referencias a este %s:",
+    "references_view_btn"          => "Ver %s %s con %s = %s",
 
 );
 ?>

--- a/core/locales/es.php
+++ b/core/locales/es.php
@@ -12,6 +12,7 @@ return array(
     '%s Details'                   => 'Detalles de %s',
     'Actions'                      => 'Acciones',
     'No records were found.'       => 'No se encontraron registros.',
+    'Export as CSV' => 'Exportar como CSV',
 
     // update records
     'Update Record'                => 'Actualizar registro',

--- a/core/locales/fr.php
+++ b/core/locales/fr.php
@@ -1,59 +1,59 @@
 <?php
 return array(
     // menus
-    'Select Page' => 'Sélectionnez un contenu',
-    'Back' => 'Retour',
-    'Back to List' => "Retour à la liste",
+    'Select Page'                  => 'Sélectionnez un contenu',
+    'Back'                         => 'Retour',
+    'Back to List'                 => "Retour à la liste",
 
     // list records
-    'View' => 'Voir',
-    'Reset View' => 'Réinitialiser les filtres',
-    'View Record' => "Voir enregistrement",
-    '%s Details' => "Liste des %s",
-    'Actions' => "Actions",
-    'No records were found.' => "Aucun enregistrement trouvé.",
-    'Export as CSV' => 'Exporter en CSV',
+    'View'                         => 'Voir',
+    'Reset View'                   => 'Réinitialiser les filtres',
+    'View Record'                  => "Voir enregistrement",
+    '%s Details'                   => "Liste des %s",
+    'Actions'                      => "Actions",
+    'No records were found.'       => "Aucun enregistrement trouvé.",
+    'Export as CSV'                => 'Exporter en CSV',
 
     // update records
-    'Update Record' => "Éditer enregistrement",
-    'update_record_instructions' => "Modifier les valeurs et validez pour éditer l'enregistrement.",
-    'Edit' => 'Éditer',
+    'Update Record'                => "Éditer enregistrement",
+    'update_record_instructions'   => "Modifier les valeurs et validez pour éditer l'enregistrement.",
+    'Edit'                         => 'Éditer',
 
     // delete records
-    'Delete' => 'Supprimer',
-    'Delete File' => 'Supprimer %s',
-    'Delete Record' => "Supprimer enregistrement",
-    'delete_record_confirm' => "Êtes-vous sûr de vouloir supprimer cet enregistrement ?",
+    'Delete'                       => 'Supprimer',
+    'Delete File'                  => 'Supprimer %s',
+    'Delete Record'                => "Supprimer enregistrement",
+    'delete_record_confirm'        => "Êtes-vous sûr de vouloir supprimer cet enregistrement ?",
 
     // add records
-    'Add New Record' => 'Ajouter un nouvel enregistrement',
-    'add_new_record_instructions' => 'Remplissez le formulaire et validez pour ajouter un enregistrement à la base de données.',
-    'Create' => 'Créer',
-    'required_fiels_instructions' => '* champ(s) obligatoire(s)',
+    'Add New Record'               => 'Ajouter un nouvel enregistrement',
+    'add_new_record_instructions'  => 'Remplissez le formulaire et validez pour ajouter un enregistrement à la base de données.',
+    'Create'                       => 'Créer',
+    'required_fiels_instructions'  => '* champ(s) obligatoire(s)',
 
 
     // search & paging
-    'Search this table' => "Rechercher",
-    'First' => "Début",
-    'Last' => "Fin",
-    'total_results' => '%s résultats - Page %s sur %s',
-    'Prev' => 'Précédent',
-    'Next' => 'Suivant',
+    'Search this table'            => "Rechercher",
+    'First'                        => "Début",
+    'Last'                         => "Fin",
+    'total_results'                => '%s résultats - Page %s sur %s',
+    'Prev'                         => 'Précédent',
+    'Next'                         => 'Suivant',
 
     // buttons
-    'Yes' => "Oui",
-    'No' => "Non",
-    'Cancel' => "Annuler",
+    'Yes'                          => "Oui",
+    'No'                           => "Non",
+    'Cancel'                       => "Annuler",
 
     // errors
-    'Error' => "Erreur",
-    'Invalid Request' => "Demande invalide",
-    'stmt_error' => 'Oups ! Une erreur est survenue. Veuillez réessayer plus tard.',
-    'unsupported_no_pk' => "L'édition de tables sans clé primaire n'est pas encore prise en charge.",
+    'Error'                        => "Erreur",
+    'Invalid Request'              => "Demande invalide",
+    'stmt_error'                   => 'Oups ! Une erreur est survenue. Veuillez réessayer plus tard.',
+    'unsupported_no_pk'            => "L'édition de tables sans clé primaire n'est pas encore prise en charge.",
     'invalid_request_instructions' => "Désolé, vous avez fait une demande invalide. Veuillez <a href='index.php' class='alert-link'>réessayer</a>.",
 
     // foreign keys
-    "references_tables" => "Liens avec %s :",
-    "references_view_btn" => "Voir %s %s avec %s = %s",
+    "references_tables"            => "Liens avec %s :",
+    "references_view_btn"          => "Voir %s %s avec %s = %s",
 );
 ?>

--- a/core/locales/fr.php
+++ b/core/locales/fr.php
@@ -12,6 +12,7 @@ return array(
     '%s Details' => "Liste des %s",
     'Actions' => "Actions",
     'No records were found.' => "Aucun enregistrement trouvé.",
+    'Export as CSV' => 'Exporter en CSV',
 
     // update records
     'Update Record' => "Éditer enregistrement",

--- a/core/locales/in.php
+++ b/core/locales/in.php
@@ -12,6 +12,7 @@ return array(
     '%s Details' => '%s का विवरण',
     'Actions' => 'कार्य',
     'No records were found.' => 'कोई रिकॉर्ड नहीं मिले।',
+    'Export as CSV' => 'CSV के रूप में निर्यात करें',
 
     // update records
     'Update Record' => 'रिकॉर्ड अपडेट करें',

--- a/core/locales/in.php
+++ b/core/locales/in.php
@@ -1,58 +1,58 @@
 <?php
 return array(
     // menus
-    'Select Page' => 'पेज का चयन करें',
-    'Back' => 'वापस',
-    'Back to List' => 'सूची में वापस जाएं',
+    'Select Page'                  => 'पेज का चयन करें',
+    'Back'                         => 'वापस',
+    'Back to List'                 => 'सूची में वापस जाएं',
 
     // list records
-    'View' => 'देखें',
-    'Reset View' => 'दृश्य रीसेट करें',
-    'View Record' => 'रिकॉर्ड देखें',
-    '%s Details' => '%s का विवरण',
-    'Actions' => 'कार्य',
-    'No records were found.' => 'कोई रिकॉर्ड नहीं मिले।',
-    'Export as CSV' => 'CSV के रूप में निर्यात करें',
+    'View'                         => 'देखें',
+    'Reset View'                   => 'दृश्य रीसेट करें',
+    'View Record'                  => 'रिकॉर्ड देखें',
+    '%s Details'                   => '%s का विवरण',
+    'Actions'                      => 'कार्य',
+    'No records were found.'       => 'कोई रिकॉर्ड नहीं मिले।',
+    'Export as CSV'                => 'CSV के रूप में निर्यात करें',
 
     // update records
-    'Update Record' => 'रिकॉर्ड अपडेट करें',
-    'update_record_instructions' => 'कृपया इनपुट मानों को संपादित करें और रिकॉर्ड को अपडेट करने के लिए सबमिट करें।',
+    'Update Record'                => 'रिकॉर्ड अपडेट करें',
+    'update_record_instructions'   => 'कृपया इनपुट मानों को संपादित करें और रिकॉर्ड को अपडेट करने के लिए सबमिट करें।',
 
     // delete records
-    'Delete' => 'Hapus',
-    'Delete File' => 'Hapus %s',
-    'Delete Record' => 'रिकॉर्ड हटाएं',
-    'delete_record_confirm' => 'क्या आप वाकई इस रिकॉर्ड को हटाना चाहते हैं?',
+    'Delete'                       => 'Hapus',
+    'Delete File'                  => 'Hapus %s',
+    'Delete Record'                => 'रिकॉर्ड हटाएं',
+    'delete_record_confirm'        => 'क्या आप वाकई इस रिकॉर्ड को हटाना चाहते हैं?',
 
     // add records
-    'Add New Record' => 'नया रिकॉर्ड जोड़ें',
-    'add_new_record_instructions' => 'कृपया इस फॉर्म को भरें और डेटाबेस में रिकॉर्ड जोड़ने के लिए सबमिट करें।',
-    'Create' => 'बनाएँ',
-    'required_fiels_instructions' => '* फ़ील्ड को खाली नहीं छोड़ा जा सकता',
+    'Add New Record'               => 'नया रिकॉर्ड जोड़ें',
+    'add_new_record_instructions'  => 'कृपया इस फॉर्म को भरें और डेटाबेस में रिकॉर्ड जोड़ने के लिए सबमिट करें।',
+    'Create'                       => 'बनाएँ',
+    'required_fiels_instructions'  => '* फ़ील्ड को खाली नहीं छोड़ा जा सकता',
 
     // search & paging
-    'Search this table' => 'इस तालिका को खोजें',
-    'First' => 'पहला',
-    'Last' => 'अंतिम',
-    'total_results' => '%s hasil - Halaman %s dari %s',
-    'Prev' => 'Sebelumnya',
-    'Next' => 'Berikutnya',
+    'Search this table'            => 'इस तालिका को खोजें',
+    'First'                        => 'पहला',
+    'Last'                         => 'अंतिम',
+    'total_results'                => '%s hasil - Halaman %s dari %s',
+    'Prev'                         => 'Sebelumnya',
+    'Next'                         => 'Berikutnya',
 
     // buttons
-    'Yes' => 'हाँ',
-    'No' => 'नहीं',
-    'Cancel' => 'रद्द करें',
+    'Yes'                          => 'हाँ',
+    'No'                           => 'नहीं',
+    'Cancel'                       => 'रद्द करें',
 
     // errors
-    'Error' => 'त्रुटि',
-    'Invalid Request' => 'अमान्य अनुरोध',
-    'stmt_error' => 'उफ़! कुछ गलत हो गया। कृपया बाद में पुनः प्रयास करें।',
-    'unsupported_no_pk' => 'प्राथमिक कुंजी के बिना टेबल का संपादन अभी तक समर्थित नहीं है।',
+    'Error'                        => 'त्रुटि',
+    'Invalid Request'              => 'अमान्य अनुरोध',
+    'stmt_error'                   => 'उफ़! कुछ गलत हो गया। कृपया बाद में पुनः प्रयास करें।',
+    'unsupported_no_pk'            => 'प्राथमिक कुंजी के बिना टेबल का संपादन अभी तक समर्थित नहीं है।',
     'invalid_request_instructions' => 'क्षमा करें, आपने एक अमान्य अनुरोध किया है। कृपया <a href="index.php" class="alert-link">वापस जाएँ</a> और पुनः प्रयास करें।',
 
     // foreign keys
-    "references_tables" => "इस %s के संदर्भ:",
-    "references_view_btn" => "%s %s को %s = %s के साथ देखें",
+    "references_tables"            => "इस %s के संदर्भ:",
+    "references_view_btn"          => "%s %s को %s = %s के साथ देखें",
 
 );
 ?>

--- a/core/locales/it.php
+++ b/core/locales/it.php
@@ -12,6 +12,7 @@ return array(
     '%s Details' => 'Dettagli di %s',
     'Actions' => 'Azioni',
     'No records were found.' => 'Nessun record trovato.',
+    'Export as CSV' => 'Esporta come CSV',
 
     // update records
     'Update Record' => 'Aggiorna record',

--- a/core/locales/it.php
+++ b/core/locales/it.php
@@ -1,58 +1,58 @@
 <?php
 return array(
     // menus
-    'Select Page' => 'Seleziona Pagina',
-    'Back' => 'Indietro',
-    'Back to List' => 'Torna alla lista',
+    'Select Page'                  => 'Seleziona Pagina',
+    'Back'                         => 'Indietro',
+    'Back to List'                 => 'Torna alla lista',
 
     // list records
-    'View' => 'Visualizza',
-    'Reset View' => 'Reimposta visualizzazione',
-    'View Record' => 'Visualizza record',
-    '%s Details' => 'Dettagli di %s',
-    'Actions' => 'Azioni',
-    'No records were found.' => 'Nessun record trovato.',
-    'Export as CSV' => 'Esporta come CSV',
+    'View'                         => 'Visualizza',
+    'Reset View'                   => 'Reimposta visualizzazione',
+    'View Record'                  => 'Visualizza record',
+    '%s Details'                   => 'Dettagli di %s',
+    'Actions'                      => 'Azioni',
+    'No records were found.'       => 'Nessun record trovato.',
+    'Export as CSV'                => 'Esporta come CSV',
 
     // update records
-    'Update Record' => 'Aggiorna record',
-    'update_record_instructions' => 'Modifica i valori e invia per aggiornare il record.',
+    'Update Record'                => 'Aggiorna record',
+    'update_record_instructions'   => 'Modifica i valori e invia per aggiornare il record.',
 
     // delete records
-    'Delete' => 'Elimina',
-    'Delete File' => 'Elimina %s',
-    'Delete Record' => 'Elimina record',
-    'delete_record_confirm' => 'Sei sicuro di voler eliminare questo record?',
+    'Delete'                       => 'Elimina',
+    'Delete File'                  => 'Elimina %s',
+    'Delete Record'                => 'Elimina record',
+    'delete_record_confirm'        => 'Sei sicuro di voler eliminare questo record?',
 
     // add records
-    'Add New Record' => 'Aggiungi nuovo record',
-    'add_new_record_instructions' => 'Compila questo modulo e invia per aggiungere un record al database.',
-    'Create' => 'Crea',
-    'required_fiels_instructions' => '* campo non può essere vuoto',
+    'Add New Record'               => 'Aggiungi nuovo record',
+    'add_new_record_instructions'  => 'Compila questo modulo e invia per aggiungere un record al database.',
+    'Create'                       => 'Crea',
+    'required_fiels_instructions'  => '* campo non può essere vuoto',
 
     // search & paging
-    'Search this table' => 'Cerca in questa tabella',
-    'First' => 'Primo',
-    'Last' => 'Ultimo',
-    'total_results' => '%s risultati - Pagina %s di %s',
-    'Prev' => 'Precedente',
-    'Next' => 'Successivo',
+    'Search this table'            => 'Cerca in questa tabella',
+    'First'                        => 'Primo',
+    'Last'                         => 'Ultimo',
+    'total_results'                => '%s risultati - Pagina %s di %s',
+    'Prev'                         => 'Precedente',
+    'Next'                         => 'Successivo',
 
     // buttons
-    'Yes' => 'Sì',
-    'No' => 'No',
-    'Cancel' => 'Annulla',
+    'Yes'                          => 'Sì',
+    'No'                           => 'No',
+    'Cancel'                       => 'Annulla',
 
     // errors
-    'Error' => 'Errore',
-    'Invalid Request' => 'Richiesta non valida',
-    'stmt_error' => 'Ops! Qualcosa è andato storto. Riprova più tardi.',
-    'unsupported_no_pk' => 'La modifica di tabelle senza chiave primaria non è ancora supportata.',
+    'Error'                        => 'Errore',
+    'Invalid Request'              => 'Richiesta non valida',
+    'stmt_error'                   => 'Ops! Qualcosa è andato storto. Riprova più tardi.',
+    'unsupported_no_pk'            => 'La modifica di tabelle senza chiave primaria non è ancora supportata.',
     'invalid_request_instructions' => 'Spiacente, hai effettuato una richiesta non valida. Per favore <a href="index.php" class="alert-link">torna indietro</a> e riprova.',
 
     // foreign keys
-    "references_tables" => "Riferimenti a questo %s:",
-    "references_view_btn" => "Visualizza %s %s con %s = %s",
+    "references_tables"            => "Riferimenti a questo %s:",
+    "references_view_btn"          => "Visualizza %s %s con %s = %s",
 
 
 );

--- a/core/locales/jp.php
+++ b/core/locales/jp.php
@@ -12,6 +12,7 @@ return array(
     '%s Details' => '%sの詳細',
     'Actions' => 'アクション',
     'No records were found.' => '記録が見つかりませんでした。',
+    'Export as CSV' => 'CSVとしてエクスポート',
 
     // update records
     'Update Record' => '記録を更新',

--- a/core/locales/jp.php
+++ b/core/locales/jp.php
@@ -1,58 +1,58 @@
 <?php
 return array(
     // menus
-    'Select Page' => 'ページを選択',
-    'Back' => '戻る',
-    'Back to List' => 'リストに戻る',
+    'Select Page'                  => 'ページを選択',
+    'Back'                         => '戻る',
+    'Back to List'                 => 'リストに戻る',
 
     // list records
-    'View' => '表示',
-    'Reset View' => '表示リセット',
-    'View Record' => '記録を見る',
-    '%s Details' => '%sの詳細',
-    'Actions' => 'アクション',
-    'No records were found.' => '記録が見つかりませんでした。',
-    'Export as CSV' => 'CSVとしてエクスポート',
+    'View'                         => '表示',
+    'Reset View'                   => '表示リセット',
+    'View Record'                  => '記録を見る',
+    '%s Details'                   => '%sの詳細',
+    'Actions'                      => 'アクション',
+    'No records were found.'       => '記録が見つかりませんでした。',
+    'Export as CSV'                => 'CSVとしてエクスポート',
 
     // update records
-    'Update Record' => '記録を更新',
-    'update_record_instructions' => '入力値を編集して記録を更新してください。',
+    'Update Record'                => '記録を更新',
+    'update_record_instructions'   => '入力値を編集して記録を更新してください。',
 
     // delete records
-    'Delete' => '削除',
-    'Delete File' => '%sを削除',
-    'Delete Record' => '記録を削除',
-    'delete_record_confirm' => 'この記録を削除してもよろしいですか？',
+    'Delete'                       => '削除',
+    'Delete File'                  => '%sを削除',
+    'Delete Record'                => '記録を削除',
+    'delete_record_confirm'        => 'この記録を削除してもよろしいですか？',
 
     // add records
-    'Add New Record' => '新しい記録を追加',
-    'add_new_record_instructions' => 'このフォームを記入してデータベースに記録を追加してください。',
-    'Create' => '作成',
-    'required_fiels_instructions' => '* 空白にできないフィールド',
+    'Add New Record'               => '新しい記録を追加',
+    'add_new_record_instructions'  => 'このフォームを記入してデータベースに記録を追加してください。',
+    'Create'                       => '作成',
+    'required_fiels_instructions'  => '* 空白にできないフィールド',
 
     // search & paging
-    'Search this table' => 'このテーブルを検索',
-    'First' => '最初',
-    'Last' => '最後',
-    'total_results' => '%s件の結果 - %sページ中の%sページ目',
-    'Prev' => '前',
-    'Next' => '次',
+    'Search this table'            => 'このテーブルを検索',
+    'First'                        => '最初',
+    'Last'                         => '最後',
+    'total_results'                => '%s件の結果 - %sページ中の%sページ目',
+    'Prev'                         => '前',
+    'Next'                         => '次',
 
     // buttons
-    'Yes' => 'はい',
-    'No' => 'いいえ',
-    'Cancel' => 'キャンセル',
+    'Yes'                          => 'はい',
+    'No'                           => 'いいえ',
+    'Cancel'                       => 'キャンセル',
 
     // errors
-    'Error' => 'エラー',
-    'Invalid Request' => '無効なリクエスト',
-    'stmt_error' => 'おっと！何か問題が発生しました。後でもう一度試してください。',
-    'unsupported_no_pk' => '主キーのない表の編集はまだサポートされていません。',
+    'Error'                        => 'エラー',
+    'Invalid Request'              => '無効なリクエスト',
+    'stmt_error'                   => 'おっと！何か問題が発生しました。後でもう一度試してください。',
+    'unsupported_no_pk'            => '主キーのない表の編集はまだサポートされていません。',
     'invalid_request_instructions' => '申し訳ありませんが、無効なリクエストを行いました。 <a href="index.php" class="alert-link">戻って</a>もう一度試してください。',
 
     // foreign keys
-    "references_tables" => "この %s への参照:",
-    "references_view_btn" => "%s %s を %s = %s で表示する",
+    "references_tables"            => "この %s への参照:",
+    "references_view_btn"          => "%s %s を %s = %s で表示する",
 
 );
 ?>

--- a/core/locales/nl.php
+++ b/core/locales/nl.php
@@ -12,6 +12,7 @@ return array(
     '%s Details' => 'Details van %s',
     'Actions' => 'Acties',
     'No records were found.' => 'Geen records gevonden.',
+    'Export as CSV' => 'Exporteren als CSV',
 
     // update records
     'Update Record' => 'Record bijwerken',

--- a/core/locales/nl.php
+++ b/core/locales/nl.php
@@ -1,58 +1,58 @@
 <?php
 return array(
     // menus
-    'Select Page' => 'Pagina selecteren',
-    'Back' => 'Terug',
-    'Back to List' => 'Terug naar lijst',
+    'Select Page'                  => 'Pagina selecteren',
+    'Back'                         => 'Terug',
+    'Back to List'                 => 'Terug naar lijst',
 
     // list records
-    'View' => 'Bekijken',
-    'Reset View' => 'Reset weergave',
-    'View Record' => 'Record bekijken',
-    '%s Details' => 'Details van %s',
-    'Actions' => 'Acties',
-    'No records were found.' => 'Geen records gevonden.',
-    'Export as CSV' => 'Exporteren als CSV',
+    'View'                         => 'Bekijken',
+    'Reset View'                   => 'Reset weergave',
+    'View Record'                  => 'Record bekijken',
+    '%s Details'                   => 'Details van %s',
+    'Actions'                      => 'Acties',
+    'No records were found.'       => 'Geen records gevonden.',
+    'Export as CSV'                => 'Exporteren als CSV',
 
     // update records
-    'Update Record' => 'Record bijwerken',
-    'update_record_instructions' => 'Bewerk de waarden en dien in om het record bij te werken.',
+    'Update Record'                => 'Record bijwerken',
+    'update_record_instructions'   => 'Bewerk de waarden en dien in om het record bij te werken.',
 
     // delete records
-    'Delete' => 'Verwijderen',
-    'Delete File' => 'Verwijderen %s',
-    'Delete Record' => 'Record verwijderen',
-    'delete_record_confirm' => 'Weet u zeker dat u dit record wilt verwijderen?',
+    'Delete'                       => 'Verwijderen',
+    'Delete File'                  => 'Verwijderen %s',
+    'Delete Record'                => 'Record verwijderen',
+    'delete_record_confirm'        => 'Weet u zeker dat u dit record wilt verwijderen?',
 
     // add records
-    'Add New Record' => 'Nieuw record toevoegen',
-    'add_new_record_instructions' => 'Vul dit formulier in en dien het in om een record aan de database toe te voegen.',
-    'Create' => 'Aanmaken',
-    'required_fiels_instructions' => '* veld kan niet leeg zijn',
+    'Add New Record'               => 'Nieuw record toevoegen',
+    'add_new_record_instructions'  => 'Vul dit formulier in en dien het in om een record aan de database toe te voegen.',
+    'Create'                       => 'Aanmaken',
+    'required_fiels_instructions'  => '* veld kan niet leeg zijn',
 
     // search & paging
-    'Search this table' => 'Zoek in deze tabel',
-    'First' => 'Eerste',
-    'Last' => 'Laatste',
-    'total_results' => '%s resultaten - Pagina %s van %s',
-    'Prev' => 'Vorige',
-    'Next' => 'Volgende',
+    'Search this table'            => 'Zoek in deze tabel',
+    'First'                        => 'Eerste',
+    'Last'                         => 'Laatste',
+    'total_results'                => '%s resultaten - Pagina %s van %s',
+    'Prev'                         => 'Vorige',
+    'Next'                         => 'Volgende',
 
     // buttons
-    'Yes' => 'Ja',
-    'No' => 'Nee',
-    'Cancel' => 'Annuleren',
+    'Yes'                          => 'Ja',
+    'No'                           => 'Nee',
+    'Cancel'                       => 'Annuleren',
 
     // errors
-    'Error' => 'Fout',
-    'Invalid Request' => 'Ongeldige aanvraag',
-    'stmt_error' => 'Oeps! Er is iets fout gegaan. Probeer het later opnieuw.',
-    'unsupported_no_pk' => 'Het bewerken van tabellen zonder primaire sleutel wordt nog niet ondersteund.',
+    'Error'                        => 'Fout',
+    'Invalid Request'              => 'Ongeldige aanvraag',
+    'stmt_error'                   => 'Oeps! Er is iets fout gegaan. Probeer het later opnieuw.',
+    'unsupported_no_pk'            => 'Het bewerken van tabellen zonder primaire sleutel wordt nog niet ondersteund.',
     'invalid_request_instructions' => 'Sorry, u hebt een ongeldige aanvraag gedaan. Ga alstublieft <a href="index.php" class="alert-link">terug</a> en probeer het opnieuw.',
 
     // foreign keys
-    "references_tables" => "Verwijzingen naar deze %s:",
-    "references_view_btn" => "Bekijk %s %s met %s = %s",
+    "references_tables"            => "Verwijzingen naar deze %s:",
+    "references_view_btn"          => "Bekijk %s %s met %s = %s",
 
 );
 ?>

--- a/core/locales/pt.php
+++ b/core/locales/pt.php
@@ -1,58 +1,58 @@
 <?php
 return array(
     // menus
-    'Select Page' => 'Selecionar Página',
-    'Back' => 'Voltar',
-    'Back to List' => 'Voltar para a Lista',
+    'Select Page'                  => 'Selecionar Página',
+    'Back'                         => 'Voltar',
+    'Back to List'                 => 'Voltar para a Lista',
 
     // list records
-    'View' => 'Visualizar',
-    'Reset View' => 'Redefinir Visualização',
-    'View Record' => 'Ver Registro',
-    '%s Details' => 'Detalhes de %s',
-    'Actions' => 'Ações',
-    'No records were found.' => 'Nenhum registro encontrado.',
-    'Export as CSV' => 'Exportar como CSV',
+    'View'                         => 'Visualizar',
+    'Reset View'                   => 'Redefinir Visualização',
+    'View Record'                  => 'Ver Registro',
+    '%s Details'                   => 'Detalhes de %s',
+    'Actions'                      => 'Ações',
+    'No records were found.'       => 'Nenhum registro encontrado.',
+    'Export as CSV'                => 'Exportar como CSV',
 
     // update records
-    'Update Record' => 'Atualizar Registro',
-    'update_record_instructions' => 'Edite os valores e submeta para atualizar o registro.',
+    'Update Record'                => 'Atualizar Registro',
+    'update_record_instructions'   => 'Edite os valores e submeta para atualizar o registro.',
 
     // delete records
-    'Delete' => 'Excluir',
-    'Delete File' => 'Excluir %s',
-    'Delete Record' => 'Excluir Registro',
-    'delete_record_confirm' => 'Tem certeza de que deseja excluir este registro?',
+    'Delete'                       => 'Excluir',
+    'Delete File'                  => 'Excluir %s',
+    'Delete Record'                => 'Excluir Registro',
+    'delete_record_confirm'        => 'Tem certeza de que deseja excluir este registro?',
 
     // add records
-    'Add New Record' => 'Adicionar Novo Registro',
-    'add_new_record_instructions' => 'Preencha este formulário e envie para adicionar um registro ao banco de dados.',
-    'Create' => 'Criar',
-    'required_fiels_instructions' => '* campo não pode estar vazio',
+    'Add New Record'               => 'Adicionar Novo Registro',
+    'add_new_record_instructions'  => 'Preencha este formulário e envie para adicionar um registro ao banco de dados.',
+    'Create'                       => 'Criar',
+    'required_fiels_instructions'  => '* campo não pode estar vazio',
 
     // search & paging
-    'Search this table' => 'Pesquisar nesta tabela',
-    'First' => 'Primeiro',
-    'Last' => 'Último',
-    'total_results' => '%s resultados - Página %s de %s',
-    'Prev' => 'Anterior',
-    'Next' => 'Próximo',
+    'Search this table'            => 'Pesquisar nesta tabela',
+    'First'                        => 'Primeiro',
+    'Last'                         => 'Último',
+    'total_results'                => '%s resultados - Página %s de %s',
+    'Prev'                         => 'Anterior',
+    'Next'                         => 'Próximo',
 
     // buttons
-    'Yes' => 'Sim',
-    'No' => 'Não',
-    'Cancel' => 'Cancelar',
+    'Yes'                          => 'Sim',
+    'No'                           => 'Não',
+    'Cancel'                       => 'Cancelar',
 
     // errors
-    'Error' => 'Erro',
-    'Invalid Request' => 'Solicitação Inválida',
-    'stmt_error' => 'Ops! Algo deu errado. Por favor, tente novamente mais tarde.',
-    'unsupported_no_pk' => 'A edição de tabelas sem chave primária ainda não é suportada.',
+    'Error'                        => 'Erro',
+    'Invalid Request'              => 'Solicitação Inválida',
+    'stmt_error'                   => 'Ops! Algo deu errado. Por favor, tente novamente mais tarde.',
+    'unsupported_no_pk'            => 'A edição de tabelas sem chave primária ainda não é suportada.',
     'invalid_request_instructions' => 'Desculpe, você fez uma solicitação inválida. Por favor, <a href="index.php" class="alert-link">volte</a> e tente novamente.',
 
     // foreign keys
-    "references_tables" => "Referências a este %s:",
-    "references_view_btn" => "Ver %s %s com %s = %s",
+    "references_tables"            => "Referências a este %s:",
+    "references_view_btn"          => "Ver %s %s com %s = %s",
 
 
 );

--- a/core/locales/pt.php
+++ b/core/locales/pt.php
@@ -12,6 +12,7 @@ return array(
     '%s Details' => 'Detalhes de %s',
     'Actions' => 'Ações',
     'No records were found.' => 'Nenhum registro encontrado.',
+    'Export as CSV' => 'Exportar como CSV',
 
     // update records
     'Update Record' => 'Atualizar Registro',

--- a/core/locales/ru.php
+++ b/core/locales/ru.php
@@ -12,6 +12,7 @@ return array(
     '%s Details'                   => 'Детали %s',
     'Actions'                      => 'Действия',
     'No records were found.'       => 'Записи не найдены.',
+    'Export as CSV' => 'Экспортировать как CSV',
 
     // update records
     'Update Record'                => 'Обновить запись',

--- a/core/locales/ru.php
+++ b/core/locales/ru.php
@@ -12,15 +12,15 @@ return array(
     '%s Details'                   => 'Детали %s',
     'Actions'                      => 'Действия',
     'No records were found.'       => 'Записи не найдены.',
-    'Export as CSV' => 'Экспортировать как CSV',
+    'Export as CSV'                => 'Экспортировать как CSV',
 
     // update records
     'Update Record'                => 'Обновить запись',
     'update_record_instructions'   => 'Измените значения и отправьте, чтобы обновить запись.',
 
     // delete records
-    'Delete' => 'Удалить',
-    'Delete File' => 'Удалить %s',
+    'Delete'                       => 'Удалить',
+    'Delete File'                  => 'Удалить %s',
     'Delete Record'                => 'Удалить запись',
     'delete_record_confirm'        => 'Вы уверены, что хотите удалить эту запись?',
 
@@ -34,9 +34,9 @@ return array(
     'Search this table'            => 'Поиск по таблице',
     'First'                        => 'Первая',
     'Last'                         => 'Последняя',
-    'total_results' => '%s результатов - Страница %s из %s',
-    'Prev' => 'Предыдущая',
-    'Next' => 'Следующая',
+    'total_results'                => '%s результатов - Страница %s из %s',
+    'Prev'                         => 'Предыдущая',
+    'Next'                         => 'Следующая',
 
     // buttons
     'Yes'                          => 'Да',
@@ -51,8 +51,8 @@ return array(
     'invalid_request_instructions' => 'Извините, вы сделали неверный запрос. Пожалуйста, <a href="index.php" class="alert-link">вернитесь назад</a> и попробуйте еще раз.',
 
     // foreign keys
-    "references_tables" => "Ссылки на этот %s:",
-    "references_view_btn" => "Посмотреть %s %s с %s = %s",
+    "references_tables"            => "Ссылки на этот %s:",
+    "references_view_btn"          => "Посмотреть %s %s с %s = %s",
 
 );
 ?>

--- a/core/relations.php
+++ b/core/relations.php
@@ -65,15 +65,6 @@ if(isset($_POST['index'])) {
     $_SESSION['gitignore'] = $gitignore;
 
 
-    $helpersfilename = 'helpers.php';
-    $handle = fopen('helpers.php', "r") or die("Unable to open Helpers file! Please check your file permissions.");;
-    $helpers = fread($handle, filesize($helpersfilename));
-    fclose($handle);
-
-    $helpersfile = fopen($destination . '/'. $helpersfilename, "w") or die("Unable to create Helpers file! Please check your file permissions");
-    fwrite($helpersfile, $helpers);
-	fclose($helpersfile);
-
     $configfile = fopen($configfilePath, "w") or die("Unable to open Config file!");
 
     $configfileTemplatePath = 'templates/config.php';

--- a/core/templates/entity-index.php
+++ b/core/templates/entity-index.php
@@ -112,6 +112,7 @@ $count_pages = "SELECT COUNT(*) AS count FROM `{TABLE_NAME}` {JOIN_CLAUSES}
                         <h2 class="float-left"><?php translate('%s Details', true, $str) ?></h2>
                         <a href="{TABLE_NAME}-create.php" class="btn btn-success float-right"><?php translate('Add New Record') ?></a>
                         <a href="{TABLE_NAME}-index.php" class="btn btn-info float-right mr-2"><?php translate('Reset View') ?></a>
+                        <a href="{TABLE_NAME}-index.php?export=csv" class="btn btn-primary float-right mr-2"><?php translate('Export as CSV') ?></a>
                         <a href="javascript:history.back()" class="btn btn-secondary float-right mr-2"><?php translate('Back') ?></a>
                     </div>
 

--- a/core/templates/entity-index.php
+++ b/core/templates/entity-index.php
@@ -198,7 +198,7 @@ $count_pages = "SELECT COUNT(*) AS count
 
                                 <?php mysqli_free_result($result); ?>
                             <?php else: ?>
-                            <p class='lead'><em><?php echo translate('No records were found.') ?></em></p>
+                            <p class='lead'><em><?php translate('No records were found.') ?></em></p>
                         <?php endif ?>
 
                     <?php else: ?>
@@ -208,7 +208,6 @@ $count_pages = "SELECT COUNT(*) AS count
                     <?php endif ?>
 
                     <?php mysqli_close($link) ?>
-                    ?>
                 </div>
             </div>
         </div>

--- a/core/templates/entity-index.php
+++ b/core/templates/entity-index.php
@@ -1,4 +1,84 @@
-<!DOCTYPE html>
+<?php
+
+require_once('config.php');
+require_once('config-tables-columns.php');
+require_once('helpers.php');
+require_once('navbar.php');
+
+//Get current URL and parameters for correct pagination
+$script   = $_SERVER['SCRIPT_NAME'];
+$parameters   = $_GET ? $_SERVER['QUERY_STRING'] : "" ;
+$currenturl = $domain. $script . '?' . $parameters;
+
+//Pagination
+if (isset($_GET['pageno'])) {
+    $pageno = $_GET['pageno'];
+} else {
+    $pageno = 1;
+}
+
+//$no_of_records_per_page is set on the index page. Default is 10.
+$offset = ($pageno-1) * $no_of_records_per_page;
+
+$total_pages_sql = "SELECT COUNT(*) FROM `{TABLE_NAME}`";
+$result = mysqli_query($link,$total_pages_sql);
+$total_rows = mysqli_fetch_array($result)[0];
+$total_pages = ceil($total_rows / $no_of_records_per_page);
+
+//Column sorting on column name
+$columns = array('{COLUMNS}');
+// Order by primary key on default
+$order = '{COLUMN_ID}';
+if (isset($_GET['order']) && in_array($_GET['order'], $columns)) {
+    $order = $_GET['order'];
+}
+
+//Column sort order
+$sortBy = array('asc', 'desc'); $sort = 'asc';
+if (isset($_GET['sort']) && in_array($_GET['sort'], $sortBy)) {
+        if($_GET['sort']=='asc') {
+        $sort='asc';
+        }
+else {
+    $sort='desc';
+    }
+}
+
+//Generate WHERE statements for param
+$where_columns = array_intersect_key($_GET, array_flip($columns));
+$get_param = "";
+$where_statement = " WHERE 1=1 ";
+foreach ( $where_columns as $key => $val ) {
+    $where_statement .= " AND `$key` = '" . mysqli_real_escape_string($link, $val) . "' ";
+    $get_param .= "&$key=$val";
+}
+
+if (!empty($_GET['search'])) {
+    $search = mysqli_real_escape_string($link, $_GET['search']);
+    if (strpos('{INDEX_CONCAT_SEARCH_FIELDS}', ',')) {
+        $where_statement .= " AND CONCAT_WS ({INDEX_CONCAT_SEARCH_FIELDS}) LIKE '%$search%'";
+    } else {
+        $where_statement .= " AND {INDEX_CONCAT_SEARCH_FIELDS} LIKE '%$search%'";
+    }
+
+} else {
+    $search = "";
+}
+
+$order_clause = !empty($order) ? "ORDER BY `$order` $sort" : '';
+$group_clause = !empty($order) && $order == '{COLUMN_ID}' ? "GROUP BY `{TABLE_NAME}`.`$order`" : '';
+
+// Prepare SQL queries
+$sql = "SELECT `{TABLE_NAME}`.* {JOIN_COLUMNS}
+        FROM `{TABLE_NAME}` {JOIN_CLAUSES}
+        $where_statement
+        $group_clause
+        $order_clause
+        LIMIT $offset, $no_of_records_per_page;";
+$count_pages = "SELECT COUNT(*) AS count FROM `{TABLE_NAME}` {JOIN_CLAUSES}
+        $where_statement";
+
+?><!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="UTF-8">
@@ -17,10 +97,6 @@
         }
     </style>
 </head>
-<?php require_once('config.php'); ?>
-<?php require_once('config-tables-columns.php'); ?>
-<?php require_once('helpers.php'); ?>
-<?php require_once('navbar.php'); ?>
 <body>
     <section class="pt-5">
         <div class="container-fluid">
@@ -41,128 +117,51 @@
 
                     <div class="form-row">
                         <form action="{TABLE_NAME}-index.php" method="get">
-                        <div class="col">
-                          <input type="text" class="form-control" placeholder="<?php translate('Search this table') ?>" name="search">
-                        </div>
-                    </div>
+                            <div class="col"> <input type="text" class="form-control" placeholder="<?php translate('Search this table') ?>" name="search"></div>
                         </form>
-                    <br>
+                        <br>
 
-                    <?php
-                    //Get current URL and parameters for correct pagination
-                    $script   = $_SERVER['SCRIPT_NAME'];
-                    $parameters   = $_GET ? $_SERVER['QUERY_STRING'] : "" ;
-                    $currenturl = $domain. $script . '?' . $parameters;
 
-                    //Pagination
-                    if (isset($_GET['pageno'])) {
-                        $pageno = $_GET['pageno'];
-                    } else {
-                        $pageno = 1;
-                    }
+                        <?php
+                        if($result = mysqli_query($link, $sql)) :
+                            if(mysqli_num_rows($result) > 0) :
+                                $number_of_results = mysqli_fetch_assoc(mysqli_query($link, $count_pages))['count'];
+                                $total_pages = ceil($number_of_results / $no_of_records_per_page);
+                                translate('total_results', true, $number_of_results, $pageno, $total_pages);
+                                ?>
 
-                    //$no_of_records_per_page is set on the index page. Default is 10.
-                    $offset = ($pageno-1) * $no_of_records_per_page;
-
-                    $total_pages_sql = "SELECT COUNT(*) FROM `{TABLE_NAME}`";
-                    $result = mysqli_query($link,$total_pages_sql);
-                    $total_rows = mysqli_fetch_array($result)[0];
-                    $total_pages = ceil($total_rows / $no_of_records_per_page);
-
-                    //Column sorting on column name
-                    $columns = array('{COLUMNS}');
-                    // Order by primary key on default
-                    $order = '{COLUMN_ID}';
-                    if (isset($_GET['order']) && in_array($_GET['order'], $columns)) {
-                        $order = $_GET['order'];
-                    }
-
-                    //Column sort order
-                    $sortBy = array('asc', 'desc'); $sort = 'asc';
-                    if (isset($_GET['sort']) && in_array($_GET['sort'], $sortBy)) {
-                          if($_GET['sort']=='asc') {
-                            $sort='asc';
-                            }
-                    else {
-                        $sort='desc';
-                        }
-                    }
-
-                    //Generate WHERE statements for param
-                    $where_columns = array_intersect_key($_GET, array_flip($columns));
-                    $get_param = "";
-                    $where_statement = " WHERE 1=1 ";
-                    foreach ( $where_columns as $key => $val ) {
-                        $where_statement .= " AND `$key` = '" . mysqli_real_escape_string($link, $val) . "' ";
-                        $get_param .= "&$key=$val";
-                    }
-
-                    if (!empty($_GET['search'])) {
-                        $search = mysqli_real_escape_string($link, $_GET['search']);
-                        if (strpos('{INDEX_CONCAT_SEARCH_FIELDS}', ',')) {
-                            $where_statement .= " AND CONCAT_WS ({INDEX_CONCAT_SEARCH_FIELDS}) LIKE '%$search%'";
-                        } else {
-                            $where_statement .= " AND {INDEX_CONCAT_SEARCH_FIELDS} LIKE '%$search%'";
-                        }
-
-                    } else {
-                        $search = "";
-                    }
-
-                    $order_clause = !empty($order) ? "ORDER BY `$order` $sort" : '';
-                    $group_clause = !empty($order) && $order == '{COLUMN_ID}' ? "GROUP BY `{TABLE_NAME}`.`$order`" : '';
-
-                    // Prepare SQL queries
-                    $sql = "SELECT `{TABLE_NAME}`.* {JOIN_COLUMNS}
-                            FROM `{TABLE_NAME}` {JOIN_CLAUSES}
-                            $where_statement
-                            $group_clause
-                            $order_clause
-                            LIMIT $offset, $no_of_records_per_page;";
-                    $count_pages = "SELECT COUNT(*) AS count FROM `{TABLE_NAME}` {JOIN_CLAUSES}
-                            $where_statement";
-
-                    if($result = mysqli_query($link, $sql)){
-                        if(mysqli_num_rows($result) > 0){
-                            $number_of_results = mysqli_fetch_assoc(mysqli_query($link, $count_pages))['count'];
-                            $total_pages = ceil($number_of_results / $no_of_records_per_page);
-                            translate('total_results', true, $number_of_results, $pageno, $total_pages);
-                            ?>
-
-                            <table class='table table-bordered table-striped'>
-                                <thead class='thead-light'>
-                                    <tr>
-                                        <?php {INDEX_TABLE_HEADERS} ?>
-                                        <th><?php translate('Actions'); ?></th>
-                                    </tr>
-                                </thead>
-                                <tbody>
-                                    <?php while($row = mysqli_fetch_array($result)): ?>
+                                <table class='table table-bordered table-striped'>
+                                    <thead class='thead-light'>
                                         <tr>
-                                            <?php {INDEX_TABLE_ROWS} ?>
-                                            <td>
-                                                <?php
-                                                $column_id = '{COLUMN_ID}';
-                                                if (!empty($column_id)): ?>
-                                                    <a id='read-<?php echo $row['{COLUMN_NAME}']; ?>' href='{TABLE_NAME}-read.php?{COLUMN_ID}=<?php echo $row['{COLUMN_NAME}']; ?>' title='<?php echo addslashes(translate('View Record', false)); ?>' data-toggle='tooltip' class='btn btn-sm btn-info'><i class='far fa-eye'></i></a>
-                                                    <a id='update-<?php echo $row['{COLUMN_NAME}']; ?>' href='{TABLE_NAME}-update.php?{COLUMN_ID}=<?php echo $row['{COLUMN_NAME}']; ?>' title='<?php echo addslashes(translate('Update Record', false)); ?>' data-toggle='tooltip' class='btn btn-sm btn-warning'><i class='far fa-edit'></i></a>
-                                                    <a id='delete-<?php echo $row['{COLUMN_NAME}']; ?>' href='{TABLE_NAME}-delete.php?{COLUMN_ID}=<?php echo $row['{COLUMN_NAME}']; ?>' title='<?php echo addslashes(translate('Delete Record', false)); ?>' data-toggle='tooltip' class='btn btn-sm btn-danger'><i class='far fa-trash-alt'></i></a>
-                                                <?php else: ?>
-                                                    <?php echo addslashes(translate('unsupported_no_pk')); ?>
-                                                <?php endif; ?>
-                                            </td>
+                                            <?php {INDEX_TABLE_HEADERS} ?>
+                                            <th><?php translate('Actions'); ?></th>
                                         </tr>
-                                    <?php endwhile; ?>
-                                </tbody>
-                            </table>
-
-
+                                    </thead>
+                                    <tbody>
+                                        <?php while($row = mysqli_fetch_array($result)): ?>
+                                            <tr>
+                                                <?php {INDEX_TABLE_ROWS} ?>
+                                                <td>
+                                                    <?php
+                                                    $column_id = '{COLUMN_ID}';
+                                                    if (!empty($column_id)): ?>
+                                                        <a id='read-<?php echo $row['{COLUMN_NAME}']; ?>' href='{TABLE_NAME}-read.php?{COLUMN_ID}=<?php echo $row['{COLUMN_NAME}']; ?>' title='<?php echo addslashes(translate('View Record', false)); ?>' data-toggle='tooltip' class='btn btn-sm btn-info'><i class='far fa-eye'></i></a>
+                                                        <a id='update-<?php echo $row['{COLUMN_NAME}']; ?>' href='{TABLE_NAME}-update.php?{COLUMN_ID}=<?php echo $row['{COLUMN_NAME}']; ?>' title='<?php echo addslashes(translate('Update Record', false)); ?>' data-toggle='tooltip' class='btn btn-sm btn-warning'><i class='far fa-edit'></i></a>
+                                                        <a id='delete-<?php echo $row['{COLUMN_NAME}']; ?>' href='{TABLE_NAME}-delete.php?{COLUMN_ID}=<?php echo $row['{COLUMN_NAME}']; ?>' title='<?php echo addslashes(translate('Delete Record', false)); ?>' data-toggle='tooltip' class='btn btn-sm btn-danger'><i class='far fa-trash-alt'></i></a>
+                                                    <?php else: ?>
+                                                        <?php echo addslashes(translate('unsupported_no_pk')); ?>
+                                                    <?php endif; ?>
+                                                </td>
+                                            </tr>
+                                        <?php endwhile; ?>
+                                    </tbody>
+                                </table>
 
 
                                 <ul class="pagination" align-right>
                                 <?php
                                     $new_url = preg_replace('/&?pageno=[^&]*/', '', $currenturl);
-                                 ?>
+                                    ?>
                                     <li class="page-item"><a class="page-link" href="<?php echo $new_url .'&pageno=1' ?>"><?php translate('First') ?></a></li>
                                     <li class="page-item <?php if($pageno <= 1){ echo 'disabled'; } ?>">
                                         <a class="page-link" href="<?php if($pageno <= 1){ echo '#'; } else { echo $new_url ."&pageno=".($pageno - 1); } ?>"><?php translate('Prev') ?></a>
@@ -174,18 +173,19 @@
                                         <a class="page-item"><a class="page-link" href="<?php echo $new_url .'&pageno=' . $total_pages; ?>"><?php translate('Last') ?></a>
                                     </li>
                                 </ul>
-<?php
-                            // Free result set
-                            mysqli_free_result($result);
-                        } else{
-                            echo "<p class='lead'><em>" . translate('No records were found.') . "</em></p>";
-                        }
-                    } else{
-                        echo "ERROR: Could not able to execute $sql. " . mysqli_error($link);
-                    }
 
-                    // Close connection
-                    mysqli_close($link);
+                                <?php mysqli_free_result($result); ?>
+                            <?php else: ?>
+                            <p class='lead'><em><?php echo translate('No records were found.') ?></em></p>
+                        <?php endif ?>
+
+                    <?php else: ?>
+                        <div class="alert alert-danger" role="alert">
+                            ERROR: Could not able to execute <?php echo $sql. " " . mysqli_error($link); ?>
+                        </div>
+                    <?php endif ?>
+
+                    <?php mysqli_close($link) ?>
                     ?>
                 </div>
             </div>

--- a/core/templates/entity-index.php
+++ b/core/templates/entity-index.php
@@ -89,7 +89,7 @@ $result = mysqli_query($link, $sql);
 // Stop further rendering for CSV export
 if ($isCsvExport) {
     $data = mysqli_fetch_all($result, MYSQLI_ASSOC);
-    exportAsCSV($data);
+    exportAsCSV($data, $tables_and_columns_names, $table_name = '{TABLE_NAME}', $debug = true);
     exit;
 }
 

--- a/core/templates/entity-index.php
+++ b/core/templates/entity-index.php
@@ -89,7 +89,7 @@ $result = mysqli_query($link, $sql);
 // Stop further rendering for CSV export
 if ($isCsvExport) {
     $data = mysqli_fetch_all($result, MYSQLI_ASSOC);
-    exportAsCSV($data, $tables_and_columns_names, $table_name = '{TABLE_NAME}', $debug = true);
+    exportAsCSV($link, $tables_and_columns_names, '{TABLE_NAME}', $debug = true);
     exit;
 }
 

--- a/core/templates/entity-index.php
+++ b/core/templates/entity-index.php
@@ -89,8 +89,7 @@ $result = mysqli_query($link, $sql);
 // Stop further rendering for CSV export
 if ($isCsvExport) {
     $data = mysqli_fetch_all($result, MYSQLI_ASSOC);
-    // exportRawTableAsCSV($link, $tables_and_columns_names, '{TABLE_NAME}', $debug = true);
-    exportAsCSV($data, $tables_and_columns_names, '{TABLE_NAME}', $debug = false);
+    exportAsCSV($data, $db_name, $tables_and_columns_names, '{TABLE_NAME}', $link, false);
     exit;
 }
 

--- a/core/templates/entity-index.php
+++ b/core/templates/entity-index.php
@@ -89,7 +89,8 @@ $result = mysqli_query($link, $sql);
 // Stop further rendering for CSV export
 if ($isCsvExport) {
     $data = mysqli_fetch_all($result, MYSQLI_ASSOC);
-    exportAsCSV($link, $tables_and_columns_names, '{TABLE_NAME}', $debug = true);
+    // exportRawTableAsCSV($link, $tables_and_columns_names, '{TABLE_NAME}', $debug = true);
+    exportAsCSV($data, $tables_and_columns_names, '{TABLE_NAME}', $debug = false);
     exit;
 }
 

--- a/tests/behat/features/admin/generate/gitignore.added.feature
+++ b/tests/behat/features/admin/generate/gitignore.added.feature
@@ -1,7 +1,7 @@
 Feature: Check .gitignore file
 
   Scenario: Check confirmation message on generate
-    And I should see "added to .gitignore."
+    And I should see either "already exists in .gitignore." or "added to .gitignore."
 
   Scenario: Check for the existence of destination subdirectory in .gitignore
     Given I have a .gitignore file


### PR DESCRIPTION
# Export your tables list as CSV with this PR!

Athough it was a challenge to develop, it's so easy to explain.

There is a **new button** here:

![](https://files.italic.fr/chrome_4hP2jhjP6m.png)

Which is translated, by the way:

![](https://files.italic.fr/chrome_XdLgkjYJui.png)

![](https://files.italic.fr/Code_HPljLApnk8.png)

Just **press it** and get a **CSV file** your table!

![](https://files.italic.fr/explorer_0GAxMSXur0.png)

The file will be named `{table-name}_export.csv`.
**Et voilà!**

![Et voilà !](https://media1.tenor.com/m/8KzsILqujmEAAAAC/poltronefosa-et-voil%C3%A0.gif)

---

## There are a few differences though.


### 1. No filtering

- The pagination "per page" limit does not apply (you download all your table)
- The sorting order is ignored.
- The search/filtering is ignored.



### 2. Related tables columns visibility

In the HTML table, the foreign key's columns are displayed into a single column, where each "Show in FK" table column is concatenated:

![](https://files.italic.fr/chrome_SpzX19ezha.png)

In the CSV export, each "Show in FK" table column is displayed as a single column:

![](https://files.italic.fr/soffice.bin_attdGJxhp8.png)

The header of the FK's columns are prefixed with the table name (ex: table `brands`, column `name`, is displayed as `Brands - Name`)

---

### 3. Empty values

In a table configured to display the name and logo fields in related tables:

![](https://files.italic.fr/chrome_9w6Whn5LjS.png)

When the field is empty:

![](https://files.italic.fr/chrome_lSSMIeaKDW.png)

In the HTML table, we don't see the empty value:

![](https://files.italic.fr/chrome_PZMo1xmYOT.png)

In the CSV export, the column is added regardless of the values of the rows:

![](https://files.italic.fr/soffice.bin_EF3eR2MBxg.png)


---

## Looking for feedbacks

- This export has been tested with char, vachar, text with linebreaks, tinyint(1) (booleans), int(11) primary keys
- It will not work for tables without primary keys
- It could produce errors if the primary key isn't numeric
- It's been tested with French accents and Windows linebreaks (CRLF)

Send feedbacks and data samples if you encounter unexpected results.

---

> **Notice: this is not pull & play.**

You need to regenerate the CRUD pages for this to work.
Which is now super easy since PR #121 !