### PR TITLE
Hotfix/131 catch invalid charset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ tests/behat/logs/*
 !tests/behat/logs/.gitkeep
 /vendor/
 **/.env
+core/app*

--- a/core/relations.php
+++ b/core/relations.php
@@ -202,7 +202,8 @@ if(isset($_POST['addkey'])){
         <div class="row">
             <div class="col-md-12 mx-auto">
                 <div class="text-center">
-                    <h4 class="mb-0">Existing Table Relations</h4><br>
+                    <h4 class="mb-0">Existing Table Relations</h4>
+                    <p><strong><?php printf("Charset: %s", $current_charset); ?></strong></p>
                     <fieldset>
                         <table class="table table-bordered">
                           <thead>

--- a/core/templates/config.php
+++ b/core/templates/config.php
@@ -31,20 +31,33 @@ $upload_disallowed_exts = array(
 );
 
 
-$protocol               = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') ? 'https' : 'http';
-$domain                 = $protocol . '://' . $_SERVER['HTTP_HOST']; // Replace domain with your domain name. (Locally typically something like localhost)
+$protocol = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') ? 'https' : 'http';
+$domain = $protocol . '://' . $_SERVER['HTTP_HOST']; // Replace domain with your domain name. (Locally typically something like localhost)
 
-$link                   = mysqli_connect($db_server, $db_user, $db_password, $db_name);
+$link = mysqli_connect($db_server, $db_user, $db_password, $db_name);
+
+// Retrieve the database character set
 $query = "SHOW VARIABLES LIKE 'character_set_database'";
 if ($result = mysqli_query($link, $query)) {
     while ($row = mysqli_fetch_row($result)) {
-        if (!$link->set_charset($row[1])) {
-            printf("Error loading character set %s: %s\n", $row[1], $link->error);
-            exit();
-        } else {
-            // printf("Current character set: %s", $link->character_set_name());
-        }
+        $charset = $row[1];
     }
 }
+
+// Check if the character set is valid
+if (!in_array($charset, mb_list_encodings())) {
+    // If invalid, use utf8mb4 as a fallback
+    $charset = "utf8mb4";
+}
+
+// Set the character set
+if (!$link->set_charset($charset)) {
+    printf("Error loading character set %s: %s\n", $charset, $link->error);
+    exit();
+} else {
+    // printf("Current character set: %s", $link->character_set_name());
+    $current_charset = $link->character_set_name();
+}
+
 
 ?>


### PR DESCRIPTION
This patch would fix https://github.com/jan-vandenberg/cruddiy/issues/131 by detecting invalid charsets (such as `utf8mb3` in MySQL 8) and replacing it with `utf8mb4` by default.


The current charset for the connection is now displayed after config submission:

![](https://files.italic.fr/chrome_MwBDlm8hZz.png)